### PR TITLE
Fix agent registration: Add missing contact_policy field

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -606,6 +606,7 @@ def _agent_to_dict(agent: Agent) -> dict[str, Any]:
         "last_active_ts": _iso(agent.last_active_ts),
         "project_id": agent.project_id,
         "attachments_policy": getattr(agent, "attachments_policy", "auto"),
+        "contact_policy": getattr(agent, "contact_policy", "auto"),
         "is_active": getattr(agent, "is_active", True),
         "deleted_ts": _iso(deleted_ts) if (deleted_ts := getattr(agent, "deleted_ts", None)) is not None else None,
     }
@@ -1352,6 +1353,7 @@ async def _get_or_create_agent(
                 program=program,
                 model=model,
                 task_description=task_description,
+                contact_policy="auto",
             )
             session.add(agent)
             try:


### PR DESCRIPTION
## Summary

Fixed `IntegrityError` during agent registration caused by missing `contact_policy` field initialization.

## Problem

Agent registration was failing with:
```
IntegrityError: NOT NULL constraint failed: agents.contact_policy
```

The database migration in PR #4 added the `contact_policy` column with a NOT NULL constraint, but the agent creation code wasn't explicitly setting this field when creating new Agent instances. SQLAlchemy wasn't using the Pydantic model's default value in the INSERT statement.

## Changes

- **src/mcp_agent_mail/app.py:1268** - Set `contact_policy="auto"` when creating new Agent instances
- **src/mcp_agent_mail/app.py:604** - Include `contact_policy` in `_agent_to_dict()` response

## Testing

✅ All existing tests pass:
- `test_agent_contact_policy_field.py` (3 tests)
- `test_global_agent_uniqueness_modes.py` (6 tests)

✅ Manual verification:
- Successfully registered new agent with auto-generated name
- Confirmed `contact_policy="auto"` is saved to database and returned in response

## Related

- Fixes regression introduced in PR #4
- Related to migration in commit 4cbf4f4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `contact_policy="auto"` when creating agents and expose `contact_policy` in agent response payloads.
> 
> - **Identity / Agent model**:
>   - Set `contact_policy="auto"` on new `Agent` creation in `register` flow.
>   - Include `contact_policy` in `_agent_to_dict()` so API responses return the field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf33de4dd4a7abaf7ac3db5a091388f8964d246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->