### PR TITLE
Add repo link to README fork section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@
 
 ## Fork Attribution
 
-### **This repository is forked from [https://github.com/Dicklesworthstone/mcp_agent_mail](https://github.com/Dicklesworthstone/mcp_agent_mail). Full credit goes to the original author for creating this innovative multi-agent coordination system.**
+### **This repository is forked from [https://github.com/Dicklesworthstone/mcp_agent_mail](https://github.com/Dicklesworthstone/mcp_agent_mail). Full credit goes to the original author for creating this innovative multi-agent coordination system.
 
-**This Repo:** [https://github.com/jleechanorg/mcp_mail](https://github.com/jleechanorg/mcp_mail)
-
-> Note: This was copied as a standalone repository rather than kept as a fork because Claude Code on the web appears to ignore forks in its repository indexing.
-
+> Note: This was copied as a standalone repository rather than kept as a fork because Codex web appears to ignore forks in its repository indexing.
 Here was my first attempt at a normal fork: [https://github.com/jleechanorg/mcp_agent_mail](https://github.com/jleechanorg/mcp_agent_mail)
 
 ## Fork Improvements


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates README’s fork attribution with a bold heading, adds a note explaining the standalone copy decision, and links to the prior fork attempt.
> 
> - **Documentation (README)**:
>   - **Fork Attribution**: Promoted attribution to a bold subheading and clarified credit to the original repo (`Dicklesworthstone/mcp_agent_mail`).
>   - **Context Note**: Added explanation that this repo is a standalone copy (for Codex indexing) and included a link to the prior fork (`jleechanorg/mcp_agent_mail`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfe9ecc16bcd413c46f2deade00af95fac8459c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with explicit repository reference and clarification regarding fork status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->