### PR TITLE
Fix CLI duplication and guard/script regressions

### DIFF
--- a/src/mcp_agent_mail/db.py
+++ b/src/mcp_agent_mail/db.py
@@ -302,7 +302,6 @@ def _check_and_fix_duplicate_agent_names(connection) -> None:
 
 
 def _setup_fts(connection) -> None:
-    _ensure_agent_active_columns(connection)
     connection.exec_driver_sql(
         "CREATE VIRTUAL TABLE IF NOT EXISTS fts_messages USING fts5(message_id UNINDEXED, subject, body)"
     )

--- a/src/mcp_agent_mail/guard.py
+++ b/src/mcp_agent_mail/guard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import subprocess
 from pathlib import Path
 
 from .config import Settings
@@ -162,7 +163,7 @@ def render_prepush_script(archive: ProjectArchive) -> str:
         "                            check=True,capture_output=True)",
         "        data = cp.stdout.decode(\"utf-8\",\"ignore\")",
         "        paths = [p for p in data.split(\"\\x00\") if p]",
-+        "        changed.extend(paths)",
+        "        changed.extend(paths)",
         "    except Exception:",
         "        continue",
         "",

--- a/tests/test_build_slots.py
+++ b/tests/test_build_slots.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -59,7 +59,7 @@ async def test_acquire_build_slot_conflict(isolated_env, tmp_path: Path):
     """Test build slot conflict detection with multiple agents."""
     server = build_mcp_server()
     settings = get_settings()
-    archive = await ensure_archive(settings, "testproject")
+    await ensure_archive(settings, "testproject")
 
     import os
     os.environ["WORKTREES_ENABLED"] = "1"

--- a/tests/test_materialized_views.py
+++ b/tests/test_materialized_views.py
@@ -5,8 +5,6 @@ import json
 import sqlite3
 from pathlib import Path
 
-import pytest
-
 from mcp_agent_mail.share import (
     build_materialized_views,
     create_performance_indexes,

--- a/tests/test_share_export.py
+++ b/tests/test_share_export.py
@@ -19,6 +19,7 @@ from mcp_agent_mail.share import (
     ShareExportError,
     build_materialized_views,
     bundle_attachments,
+    create_performance_indexes,
     finalize_snapshot_for_export,
     maybe_chunk_database,
     scrub_snapshot,


### PR DESCRIPTION
## Summary
- remove duplicate CLI command definitions, add the amctl subapp, and harden build-slot helpers including sanitized components and renewed lease persistence
- prevent share update from deleting VCS metadata while rewriting the preview/deploy flow around a temporary bundle workspace
- repair the pre-push guard template, add the missing subprocess import, and update viewer/test utilities for the current share API and materialized-view features

## Testing
- ✅ `ruff check --fix --unsafe-fixes`
- ✅ `uvx ty check`
- ⚠️ `pytest tests/test_share_update.py` *(fails: missing fastmcp dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911d2a63a5c832f853da5777a3ba7d6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates/expands CLI (adds amctl), reworks share wizard to use a temp workspace with unified deploy, prevents share update from removing VCS metadata, hardens build-slot/guard logic, and updates viewer/materialized views and tests.
> 
> - **CLI**:
>   - Add `amctl` subapp (`amctl env`, `am-run`) and fix arg handling/escaping.
>   - Remove duplicate commands; keep single `mail status` and `projects adopt`.
>   - Share update `_copy_bundle_contents` now preserves VCS dirs (e.g., `.git`, `.github`, `.hg`, `.svn`).
> - **Share Wizard (scripts/share_to_github_pages.py)**:
>   - Export to a temporary workspace for preview; print temp path and handle cancelation cleanly.
>   - Unify deploy flow for `local`, `github-new`, and `cloudflare-pages`; save signing key path in config; improve post-deploy messages.
> - **Build Slots**:
>   - Skip malformed `expires_ts` entries; ensure slot dir exists during renew; minor CLI renew/release robustness.
> - **Guard**:
>   - Add missing `subprocess` import; fix pre-push template to correctly aggregate changed paths.
> - **DB/Share**:
>   - Materialized views handle missing `sender_id`; indexes and views unchanged otherwise; drop unused FTS setup call.
> - **Viewer**:
>   - `loadMessageBodyById` returns body string; recipients built via single query map for performance.
> - **Tests**:
>   - Update for new finalize/bundling APIs, deployment flow, and viewer/query changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38af53ead5b908659b0219b54250bb43283b1abe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->