### PR TITLE
fix push vs pull request CI Incomplete session description provided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 name: CI
 
 on:
+  pull_request:
   push:
-    branches: ["**"]
-  # Run on pull_request only for draft PRs or when requested
-  # This avoids duplicate runs since push events also trigger for PRs
+    branches: [main, develop]
+  # This avoids duplicate runs:
+  # - PR branches trigger pull_request (not push)
+  # - Direct pushes to main/develop trigger push (post-merge validation)
 
 jobs:
   ruff:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,12 @@
 name: Integration Tests
 
 on:
+  pull_request:
   push:
-    branches: ["**"]
-  # Run on pull_request only for draft PRs or when requested
-  # This avoids duplicate runs since push events also trigger for PRs
+    branches: [main, develop]
+  # This avoids duplicate runs:
+  # - PR branches trigger pull_request (not push)
+  # - Direct pushes to main/develop trigger push (post-merge validation)
 
 jobs:
   integration-tests:


### PR DESCRIPTION
Changes:
- Replace push: ["**"] with pull_request + push:[main,develop]
- Eliminates duplicate CI runs on PR branches
- PR branches now trigger via pull_request event only
- Main/develop get post-merge validation via push event
- Follows GitHub Actions best practices

Benefits:
✅ No duplication (each event triggers CI exactly once) ✅ More explicit intent (PRs vs post-merge)
✅ Resource efficient
✅ Works for all PR branches (no pattern restrictions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CI and Integration workflows to trigger on pull_request and only push to main/develop, preventing duplicate runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ba05c2d4e5d0a844747f613afe718d598e53eb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->