### PR TITLE
Add slash commands from git submodule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,16 @@ This script:
 
 With the server running, Claude agents can call `ensure_project`, `register_agent`, `fetch_inbox`, and the other MCP tools without additional setup.
 
+## Slash Commands
+
+Custom slash commands are available in the git submodule at `claude-commands/.claude/commands/`. Claude Code agents should look for slash command definitions in this directory in addition to the standard `.claude/commands/` location.
+
+To use these commands:
+- Commands are defined as markdown files in `claude-commands/.claude/commands/`
+- Invoke commands with the `/` prefix (e.g., `/command-name`)
+- The git submodule contains shared commands that can be used across multiple projects
+- Ensure the submodule is initialized: `git submodule update --init --recursive`
+
 ## GitHub Authentication
 
 A GitHub token is available for use by agents via the `GITHUB_TOKEN` environment variable:


### PR DESCRIPTION
Instructs Claude Code agents to look for custom slash commands in the claude-commands/.claude/commands/ git submodule directory in addition to the standard .claude/commands/ location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents custom slash commands in `claude-commands/.claude/commands/` and how to enable/use them via the git submodule.
> 
> - **Docs (`CLAUDE.md`)**:
>   - Add section on custom slash commands in `claude-commands/.claude/commands/`.
>     - Instruct agents to read commands from the submodule directory in addition to `.claude/commands/`.
>     - Provide usage notes (invoke with `/`, shared across projects).
>     - Include setup step to init submodule: `git submodule update --init --recursive`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad51ec874c966bee1b7a09c10f9b25dd46a7f4e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->