### PR TITLE
Fix global inbox mention search and tighten tests

### DIFF
--- a/tests/integration/test_mcp_mail_crud.py
+++ b/tests/integration/test_mcp_mail_crud.py
@@ -456,6 +456,7 @@ async def test_mark_message_as_read(mcp_mail_repo):
     assert success
 
     message = read_message_by_id(mcp_mail_repo, msg_id)
+    assert message is not None
     assert message["metadata"]["read"] is True
 
 
@@ -476,6 +477,7 @@ async def test_add_tags_to_message(mcp_mail_repo):
     assert success
 
     message = read_message_by_id(mcp_mail_repo, msg_id)
+    assert message is not None
     assert "bug" in message["metadata"]["tags"]
     assert "high-priority" in message["metadata"]["tags"]
 

--- a/tests/test_share_export.py
+++ b/tests/test_share_export.py
@@ -234,8 +234,10 @@ def test_bundle_attachments_handles_modes(tmp_path: Path) -> None:
     assert (tmp_path / "out" / path_value).is_file()
     # Large file is now detached to bundles/ instead of marked as external
     assert attachments[2]["type"] == "file"
-    assert attachments[2]["path"].startswith("attachments/bundles/")
-    assert (tmp_path / "out" / attachments[2]["path"]).is_file()
+    bundle_path_value = attachments[2]["path"]
+    assert isinstance(bundle_path_value, str)
+    assert bundle_path_value.startswith("attachments/bundles/")
+    assert (tmp_path / "out" / bundle_path_value).is_file()
     assert attachments[3]["type"] == "missing"
 
     inline_data = attachments[0]["data_uri"]


### PR DESCRIPTION
## Summary
- ensure `_find_mentions_in_global_inbox` uses a proper SQLAlchemy join against the `fts_messages` virtual table so mention detection works again (fixes failing global inbox tests and addresses the missing c1 bug fix)
- add a SQLAlchemy `table()` representation and `cast()` to keep queries type-safe, and make `search_mailbox` consistently return `ToolResult`
- harden integration tests (`tests/integration/test_mcp_mail_crud.py`, `tests/test_share_export.py`) with not-None checks and `isinstance` guards so type checking stops flagging them
- `tests/test_global_inbox_scanning.py::test_inbox_includes_messages_mentioning_agent_from_global_inbox` now passes with the FTS join fix

## Testing
- `uv run pytest tests/test_global_inbox_scanning.py::test_inbox_includes_messages_mentioning_agent_from_global_inbox -q`
- `ruff check --fix --unsafe-fixes`
- `uvx ty check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes FTS join for global inbox mention search and standardizes search_mailbox to return ToolResult, plus minor type-safety and test robustness tweaks.
> 
> - **Search/Inbox**:
>   - Fix FTS join in `_find_mentions_in_global_inbox` by joining SQLAlchemy `table("fts_messages")` via `Message.id == fts_messages.c.rowid` (replaces raw text join).
>   - Add `from sqlalchemy.sql import table, column` and define `fts_messages` columns (`rowid`, `subject`, `body`).
>   - Type-safety: cast `MessageRecipient.message_id` for `.in_(message_ids)` in `_list_outbox`.
> - **Tools API**:
>   - Change `search_mailbox(...)` return type to `ToolResult`; update docstring and return empty `ToolResult` on errors/no results.
> - **Tests**:
>   - Strengthen assertions with not-None and `isinstance` checks in `tests/integration/test_mcp_mail_crud.py` and `tests/test_share_export.py` (e.g., attachment path variables).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f150ba91ac7099f505edc82b2ed22f9e5a6ab904. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in search operations to provide structured responses for invalid queries and empty result sets.

* **Performance**
  * Optimized global inbox search performance with enhanced query execution.

* **Tests**
  * Strengthened message metadata update tests with additional null-value assertions to ensure data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->