### PR TITLE
Tighten pseudonym stats and attachment copy counts

### DIFF
--- a/src/mcp_agent_mail/share.py
+++ b/src/mcp_agent_mail/share.py
@@ -755,9 +755,6 @@ def scrub_snapshot(
                 # Update agent name in database
                 conn.execute("UPDATE agents SET name = ? WHERE id = ?", (pseudonym, agent_id))
                 agents_pseudonymized += 1
-        else:
-            # No salt provided - skip pseudonymization
-            agents_pseudonymized = 0
 
         ack_cursor = conn.execute("UPDATE messages SET ack_required = 0")
         ack_flags_cleared = ack_cursor.rowcount or 0
@@ -1365,6 +1362,7 @@ def bundle_attachments(
                     if not dest_path.exists():
                         dest_path.write_bytes(data)
                         bytes_copied += size
+                        copied_count += 1
                     bundles[sha256] = rel_path
                     media_record["mode"] = "detached"
                     media_record["bundle_path"] = rel_path.as_posix()
@@ -1378,7 +1376,6 @@ def bundle_attachments(
                             "path": rel_path.as_posix(),
                         }
                     )
-                    copied_count += 1
                     changed = True
                     continue
 
@@ -1390,6 +1387,7 @@ def bundle_attachments(
                     if not dest_path.exists():
                         dest_path.write_bytes(data)
                         bytes_copied += size
+                        copied_count += 1
                     bundles[sha256] = rel_path
                 media_record["mode"] = "file"
                 media_record["bundle_path"] = rel_path.as_posix()
@@ -1403,7 +1401,6 @@ def bundle_attachments(
                         "path": rel_path.as_posix(),
                     }
                 )
-                copied_count += 1
                 if sha_hint and sha_hint != sha256:
                     media_record["sha_hint"] = sha_hint
                 changed = True


### PR DESCRIPTION
## Summary
- drop the redundant no-salt branch in `scrub_snapshot` so the pseudonym counters remain untouched when saltless exports are requested
- ensure bundle attachment stats only increment `copied` when a detached file is actually written to disk, preventing over-counting across reused checksums

## Testing
- `uv run pytest tests/test_share_export.py tests/test_share_update.py tests/test_prepush_guard.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f8485544832f80b18f514863e8cc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the no-salt pseudonymization branch and only increment `copied_count` when a bundle file is actually written, preventing stat skew.
> 
> - **share.py**
>   - **Scrubbing**: Remove redundant no-salt branch in `scrub_snapshot`; `agents_pseudonymized` only reflects actual pseudonymization.
>   - **Attachments**: In `bundle_attachments`, move `copied_count += 1` inside write paths for both detached and regular files so it increments only when a new file is written (avoids over-counting for reused checksums).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29e370ef25f755860751bd103c0d9853d25434d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->