### PR TITLE
Fix export command environment variable handling in tests

### DIFF
--- a/tests/integration/test_mailbox_share_integration.py
+++ b/tests/integration/test_mailbox_share_integration.py
@@ -224,13 +224,6 @@ def test_share_export_end_to_end(monkeypatch, tmp_path: Path) -> None:
     assert "## GitHub Pages (detected)" in deployment_text
 
 
-@pytest.mark.skip(
-    reason=(
-        "Viewer rewritten in Alpine.js - export workflow needs fixing. "
-        "Export command fails to find test database (env var issue). "
-        "See mcp_agent_mail-au2 and mcp_agent_mail-3mb for details."
-    )
-)
 @pytest.mark.usefixtures("isolated_env")
 def test_viewer_playwright_smoke(monkeypatch, tmp_path: Path) -> None:
     playwright_sync = pytest.importorskip("playwright.sync_api")
@@ -265,6 +258,10 @@ def test_viewer_playwright_smoke(monkeypatch, tmp_path: Path) -> None:
             "--detach-threshold",
             "10240",
         ],
+        env={
+            "DATABASE_URL": f"sqlite+aiosqlite:///{db_path}",
+            "STORAGE_ROOT": str(storage_root),
+        },
     )
     assert result.exit_code == 0, result.output
 


### PR DESCRIPTION
The test_viewer_playwright_smoke test was skipped because CliRunner.invoke() doesn't inherit monkeypatched environment variables. This fix passes the DATABASE_URL and STORAGE_ROOT explicitly via the env parameter, allowing the export command to find the test database when Playwright is available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Re-enables the Playwright viewer smoke test and fixes the export command by explicitly passing DATABASE_URL and STORAGE_ROOT to CliRunner.invoke().
> 
> - **Integration Tests**:
>   - **Viewer smoke test**: Unskips `test_viewer_playwright_smoke`, re-enabling Playwright-based verification.
>   - **Export env handling**: Passes `env` to `CliRunner.invoke(...)` with `DATABASE_URL` and `STORAGE_ROOT` so `share export` locates the test DB and storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e81bddd3e103c5801effe16661b7184a086654a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->