### PR TITLE
fix: Wrap bare URL in backticks for markdown compliance

### DIFF
--- a/.claude/skills/mcp-server.md
+++ b/.claude/skills/mcp-server.md
@@ -62,7 +62,7 @@ curl -s http://127.0.0.1:8765/health | jq '.'
 
 ## Server Details
 
-- **Endpoint:** http://127.0.0.1:8765/mcp/
+- **Endpoint:** `http://127.0.0.1:8765/mcp/`
 - **Log File:** /tmp/mcp_agent_mail_server.log
 - **Script:** ./scripts/run_server_with_token.sh
 - **Command:** `uv run python -m mcp_agent_mail.cli serve-http`


### PR DESCRIPTION
## Summary

Fixes markdown linting issue (MD034) that was missed in PR #53.

## Changes

- Wrap bare URL `http://127.0.0.1:8765/mcp/` in backticks in the Server Details section

## Context

This fix was originally committed as `fd797bf` but was made after PR #53 was already merged. This followup PR ensures the markdown linting compliance is applied to main.

## Verification

- ✅ URL wrapped in backticks
- ✅ Markdown linting compliant (MD034)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the endpoint URL in backticks in `.claude/skills/mcp-server.md` to comply with markdown linting (MD034).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 482b8972980cc9d36a3cc78a52a5cede2642d494. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Applied consistent inline code formatting to all endpoint references throughout documentation for improved visual clarity, better readability, and enhanced consistency across multiple sections.
  * Enhanced technical documentation presentation by adhering to markdown best practices, ensuring endpoint information is more visually distinct and easier for users to quickly identify and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->