### PR TITLE
Bump version to 0.1.6 and fix Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp_mail"
-version = "0.1.2"
+version = "0.1.6"
 description = "Coordinated multi-agent messaging and coordination MCP server."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/run_server_pypi.sh
+++ b/scripts/run_server_pypi.sh
@@ -15,24 +15,25 @@ echo "🔄 Installing mcp_mail from PyPI..."
 TEMP_ENV=$(mktemp -d -t mcp_mail-XXXXXX)
 trap 'rm -rf "$TEMP_ENV"' EXIT
 
-# Find Python 3.11+ (prefer the default python3 if it meets the requirement)
+# Find Python 3.11-3.13 (Python 3.14+ has Pydantic type annotation compatibility issues)
 PYTHON_BIN=""
 MIN_VERSION=311  # e.g. 3.11 -> 311, 3.12 -> 312
+MAX_VERSION=313  # Python 3.14+ has Pydantic type annotation compatibility issues
 
-if command -v python3 >/dev/null 2>&1; then
+# Try specific stable versions first
+for py in python3.13 python3.12 python3.11; do
+  if command -v "$py" >/dev/null 2>&1; then
+    PYTHON_BIN=$(command -v "$py")
+    break
+  fi
+done
+
+# Fallback to default python3 if it's in the acceptable range
+if [[ -z "$PYTHON_BIN" ]] && command -v python3 >/dev/null 2>&1; then
   PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}{sys.version_info.minor:02d}")')
-  if [[ "$PY_VER" -ge "$MIN_VERSION" ]]; then
+  if [[ "$PY_VER" -ge "$MIN_VERSION" ]] && [[ "$PY_VER" -le "$MAX_VERSION" ]]; then
     PYTHON_BIN=$(command -v python3)
   fi
-fi
-
-if [[ -z "$PYTHON_BIN" ]]; then
-  for py in python3.15 python3.14 python3.13 python3.12 python3.11; do
-    if command -v "$py" >/dev/null 2>&1; then
-      PYTHON_BIN=$(command -v "$py")
-      break
-    fi
-  done
 fi
 
 if [[ -z "$PYTHON_BIN" ]]; then

--- a/uv.lock
+++ b/uv.lock
@@ -1646,7 +1646,7 @@ wheels = [
 
 [[package]]
 name = "mcp-mail"
-version = "0.1.2"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiolimiter" },
@@ -3019,6 +3019,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/cd/150fdb96b8fab27fe08d8a59fe67554568727981806e6bc2677a16081ec7/ruamel_yaml_clib-0.2.14-cp314-cp314-win32.whl", hash = "sha256:9b4104bf43ca0cd4e6f738cb86326a3b2f6eef00f417bd1e7efb7bdffe74c539", size = 102394, upload-time = "2025-11-14T21:57:36.703Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e6/a3fa40084558c7e1dc9546385f22a93949c890a8b2e445b2ba43935f51da/ruamel_yaml_clib-0.2.14-cp314-cp314-win_amd64.whl", hash = "sha256:13997d7d354a9890ea1ec5937a219817464e5cc344805b37671562a401ca3008", size = 122673, upload-time = "2025-11-14T21:57:38.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump version from 0.1.2 to 0.1.6 (published to PyPI)
- Fix Python 3.14 compatibility issues in `run_server_pypi.sh`
- Align PyPI server script with local build script behavior

## Changes
1. **Version bump**: Updated `pyproject.toml` from 0.1.2 → 0.1.6
2. **Python version constraints**: Modified `scripts/run_server_pypi.sh` to restrict to Python 3.11-3.13
3. **Improved version selection**: Try specific stable versions before falling back to default python3

## Rationale
Python 3.14 RC has Pydantic type annotation compatibility issues that cause the server to fail at startup with:
```
TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'
```

This fix ensures the PyPI installation script uses compatible Python versions (3.11-3.13), matching the behavior already implemented in `run_server_local_build.sh`.

## Testing
✅ Successfully published mcp_mail 0.1.6 to PyPI
✅ Verified server starts correctly with Python 3.13.7
✅ Tested all core MCP mail features:
- Health check
- Project creation
- Agent registration
- Message sending
- Inbox fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps to 0.1.6 and updates the PyPI server script to select Python 3.11–3.13 (preferring 3.13→3.11) with bounded fallback.
> 
> - **Release**
>   - Bump `mcp_mail` version to `0.1.6` in `pyproject.toml`.
> - **Scripts** (`scripts/run_server_pypi.sh`)
>   - Constrain Python to `3.11–3.13` (cap via `MAX_VERSION=313`).
>   - Prefer `python3.13` → `python3.12` → `python3.11` before falling back to `python3` if within bounds.
>   - Keep `uv` requirement and virtualenv install flow unchanged; improve version detection logic and messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af8346515ec284c7e4b6ccc0ce0445c770cb2e16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->