### PR TITLE
Fix agents not reading messages after registration

### DIFF
--- a/BUG_REPRODUCTION_VALIDATION.md
+++ b/BUG_REPRODUCTION_VALIDATION.md
@@ -46,7 +46,7 @@ await _ensure_global_inbox_agent(project)  # Line 687
 ### Step 2: Run Tests
 
 ```bash
-$ uv run pytest tests/test_multiagent_registration_session_bug.py::test_multiple_agents_register_with_global_inbox -x
+uv run pytest tests/test_multiagent_registration_session_bug.py::test_multiple_agents_register_with_global_inbox -x
 ```
 
 **Result**: ❌ **FAILED**
@@ -78,7 +78,7 @@ await _ensure_global_inbox_agent(project, session=session)  # Line 687
 ### Step 4: Verify Tests Pass
 
 ```bash
-$ uv run pytest tests/test_multiagent_registration_session_bug.py tests/test_agent_message_reading_after_registration.py -v
+uv run pytest tests/test_multiagent_registration_session_bug.py tests/test_agent_message_reading_after_registration.py -v
 ```
 
 **Result**: ✅ **6 passed in 13.53s**
@@ -213,4 +213,4 @@ def test_multiple_agents_register_with_global_inbox():
 - Beads Issue: MCP-fq5
 - Fix Commit: `68c4751` (Release v0.1.9)
 - Test Commit: `df0bbb2`
-- SQLAlchemy Docs: https://sqlalche.me/e/20/bhk3
+- SQLAlchemy Docs: <https://sqlalche.me/e/20/bhk3>

--- a/tests/test_agent_message_reading_after_registration.py
+++ b/tests/test_agent_message_reading_after_registration.py
@@ -80,9 +80,9 @@ async def test_agent_reads_messages_immediately_after_registration(isolated_env)
 
         # Step 5: Verify message is visible
         inbox_messages = (
-            inbox_result.structured_content["result"]
+            inbox_result.structured_content.get("result", inbox_result.data)
             if hasattr(inbox_result, "structured_content")
-            else inbox_result
+            else inbox_result.data
         )
         assert len(inbox_messages) > 0, "Inbox should not be empty after message was sent"
         matching = [msg for msg in inbox_messages if msg["id"] == message_id]
@@ -123,9 +123,9 @@ async def test_brand_new_agent_fetch_inbox_empty(isolated_env):
 
         # Should return empty list, not error
         inbox_messages = (
-            inbox_result.structured_content["result"]
+            inbox_result.structured_content.get("result", inbox_result.data)
             if hasattr(inbox_result, "structured_content")
-            else inbox_result
+            else inbox_result.data
         )
         assert isinstance(inbox_messages, list)
         assert len(inbox_messages) == 0

--- a/tests/test_multiagent_registration_session_bug.py
+++ b/tests/test_multiagent_registration_session_bug.py
@@ -110,9 +110,9 @@ async def test_multiple_agents_register_with_global_inbox(isolated_env):
             },
         )
         messages = (
-            agent2_inbox.structured_content["result"]
+            agent2_inbox.structured_content.get("result", agent2_inbox.data)
             if hasattr(agent2_inbox, "structured_content")
-            else agent2_inbox
+            else agent2_inbox.data
         )
         # Agent2 should have at least one message
         assert len(messages) >= 1
@@ -126,9 +126,9 @@ async def test_multiple_agents_register_with_global_inbox(isolated_env):
             },
         )
         messages = (
-            agent3_inbox.structured_content["result"]
+            agent3_inbox.structured_content.get("result", agent3_inbox.data)
             if hasattr(agent3_inbox, "structured_content")
-            else agent3_inbox
+            else agent3_inbox.data
         )
         assert isinstance(messages, list)
         assert len(messages) >= 1


### PR DESCRIPTION
This commit adds comprehensive test coverage for agent registration and message reading functionality, validating the fix for MCP-fq5 (database session bug).

## Problem Context

Issue MCP-fq5: "Agents aren't properly reading messages after registration"
- Root cause: Database session bug in _ensure_project() where nested sessions caused SQLAlchemy detached instance errors
- Symptom: InvalidRequestError during agent registration, preventing message reading
- Fixed in: commit 68c47518 (2025-11-18) by passing session parameter

## Test Files Added

1. **test_agent_message_reading_after_registration.py**
   - Tests basic agent registration + immediate message reading
   - Tests brand new agents can fetch empty inbox without errors
   - Tests auto_fetch_inbox parameter on first registration
   - Validates end-to-end message flow works correctly

2. **test_multiagent_registration_session_bug.py**
   - Tests multi-agent registration in same project (would trigger the bug)
   - Tests agent re-registration with profile updates
   - Tests multiple sequential registrations (stress test for session handling)
   - Specifically validates MCP-fq5 fix by registering multiple agents

## Test Results

All 6 tests PASS with the current code (fix already applied):
- test_agent_reads_messages_immediately_after_registration ✅
- test_brand_new_agent_fetch_inbox_empty ✅
- test_agent_auto_fetch_inbox_on_registration ✅
- test_multiple_agents_register_with_global_inbox ✅
- test_agent_reregistration_with_same_name ✅
- test_concurrent_agent_registration_same_project ✅

## Why These Tests Matter

These tests would have caught the MCP-fq5 bug before it reached production:
- The old code (without session parameter) would fail on Agent 2+ registration
- The new code (with session parameter) passes all tests
- Ensures agents can read messages immediately after successful registration

## Technical Details

The fix ensures that _ensure_project() reuses the outer database session when calling _ensure_global_inbox_agent(), preventing the nested session issue that caused project objects to become detached from the session context.

Ref: Beads issue MCP-fq5, commit 68c47518

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tests validating MCP-fq5 (agent registration/inbox and session handling) and a detailed reproduction/validation document.
> 
> - **Tests**:
>   - Add `tests/test_agent_message_reading_after_registration.py` covering immediate message reading, empty inbox for new agents, and `auto_fetch_inbox` on first registration.
>   - Add `tests/test_multiagent_registration_session_bug.py` validating multi-agent registration within the same project, re-registration updates, and sequential registrations; verifies messaging and inbox fetching.
> - **Docs**:
>   - Add `BUG_REPRODUCTION_VALIDATION.md` detailing MCP-fq5 reproduction steps, root cause, applied fixes (`expire_on_commit=False` and passing `session`), and test validation results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74506053bed6376738a22f41e997a541a08231ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for agent message delivery, inbox fetching (including empty inboxes and auto-fetch semantics), and multi-agent registration flows (concurrent and re-registration scenarios).
* **Documentation**
  * Added a bug reproduction & validation guide detailing steps, diagnosis, and validation outcomes for the registration/inbox issue.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->