### PR TITLE
Address review feedback for disconnect handling

### DIFF
--- a/tests/test_http_closed_resource_error.py
+++ b/tests/test_http_closed_resource_error.py
@@ -12,7 +12,6 @@ Error trace being addressed:
 
 from __future__ import annotations
 
-import asyncio
 import contextlib
 from typing import Any
 from unittest.mock import patch
@@ -251,13 +250,11 @@ async def test_server_recovers_after_closed_resource_error(isolated_env, monkeyp
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         # First request triggers ClosedResourceError
         with patch.object(StreamableHTTPServerTransport, 'handle_request', patched_handle_request):
-            try:
+            with contextlib.suppress(Exception):
                 await client.post(
                     settings.http.path,
                     json=_rpc("tools/call", {"name": "health_check", "arguments": {}}),
                 )
-            except Exception:
-                pass  # Expected to fail or be handled
 
         # Second request (without patch) should work - server has recovered
         r2 = await client.post(


### PR DESCRIPTION
## Summary
- move anyio import to module scope and refine disconnect cleanup by awaiting cancellation, narrowing termination suppression, and reusing ExceptionGroup handling
- clean up integration tests for disconnect handling (log assertions, unused imports/loop variables) and add clarifying comments
- simplify unit test suppression and remove unused imports

## Testing
- uv run pytest tests/test_http_closed_resource_error.py tests/integration/test_closed_resource_error_integration.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69225c5b7c74832fb05dbaf3e7a00e9e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve MCP HTTP transport cleanup to cancel/await server tasks and suppress ClosedResourceError (including in ExceptionGroup), with new integration/unit tests verifying robustness and logs.
> 
> - **HTTP transport (`src/mcp_agent_mail/http.py`)**:
>   - Cancel and await MCP server task before exiting to avoid reads on closed streams.
>   - Narrow termination handling: call `terminate()` with explicit handling for `anyio.ClosedResourceError` and log unexpected errors.
>   - Suppress `anyio.ClosedResourceError` from client disconnects and filter `ExceptionGroup`/`BaseExceptionGroup` to re-raise only non-ClosedResourceError exceptions.
>   - Add module-level `anyio` import.
> - **Tests**:
>   - Add integration tests (`tests/integration/test_closed_resource_error_integration.py`) to simulate mid-stream disconnects and assert server remains responsive and logs contain no ASGI exceptions.
>   - Add unit tests (`tests/test_http_closed_resource_error.py`) to ensure `ClosedResourceError` during `connect()`/`handle_request()` and within `ExceptionGroup` is suppressed and server recovers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a7d7048d63b8b0412b24f87415a623ab4360f3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->