### PR TITLE
Handle ExceptionGroup fallback robustly for disconnect filtering

### DIFF
--- a/docs/fix_closed_resource_error.md
+++ b/docs/fix_closed_resource_error.md
@@ -117,7 +117,10 @@ except anyio.ClosedResourceError:
 except (ExceptionGroup, BaseExceptionGroup) as eg:
     non_closed = [e for e in eg.exceptions if not isinstance(e, anyio.ClosedResourceError)]
     if non_closed:
-        derived = eg.derive(non_closed) if hasattr(eg, "derive") else type(eg)(eg.args[0], non_closed)
+        derived = eg.derive(non_closed) if hasattr(eg, "derive") else type(eg)(
+            eg.message if hasattr(eg, "message") else (eg.args[0] if eg.args else str(eg)),
+            non_closed,
+        )
         raise derived from eg
 ```
 

--- a/src/mcp_agent_mail/http.py
+++ b/src/mcp_agent_mail/http.py
@@ -975,10 +975,13 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
                 # and re-raise if there are other non-suppressible exceptions
                 non_closed = [e for e in eg.exceptions if not isinstance(e, anyio.ClosedResourceError)]
                 if non_closed:
-                    derived = (
-                        eg.derive(non_closed)
-                        if hasattr(eg, "derive")
-                        else type(eg)(eg.args[0], non_closed)
+                    derived = eg.derive(non_closed) if hasattr(eg, "derive") else type(
+                        eg
+                    )(
+                        eg.message
+                        if hasattr(eg, "message")
+                        else (eg.args[0] if eg.args else str(eg)),
+                        non_closed,
                     )
                     raise derived from eg
 


### PR DESCRIPTION
## Summary
- make ExceptionGroup fallback reconstruction use a safe message source (prefer `message`, fall back to args/str) when derive is unavailable
- align documentation snippet with the updated ExceptionGroup handling logic

## Testing
- uv run ruff check src/mcp_agent_mail/http.py tests/test_http_closed_resource_error.py tests/integration/test_closed_resource_error_integration.py
- uv run pytest tests/test_http_closed_resource_error.py tests/integration/test_closed_resource_error_integration.py -q --disable-warnings


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ab72a11c832f9797bb16d31000c5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely reconstructs ExceptionGroup when derive() is unavailable by using message/args/str and updates the docs snippet to match.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cf580918e090d14eb782feb11fa8f240e3b1578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->