### PR TITLE
Improve Slack message agent visibility

### DIFF
--- a/src/mcp_agent_mail/slack_integration.py
+++ b/src/mcp_agent_mail/slack_integration.py
@@ -360,8 +360,12 @@ def format_mcp_message_for_slack(
         "low": ":information_source:",
     }.get(importance, ":email:")
 
-    # Fallback text for notifications with importance indicator
-    text = f"{importance_emoji} *{subject}* from {sender_name}"
+    # Fallback text for notifications with importance indicator and full routing info
+    if recipients:
+        recipient_list = ", ".join(recipients)
+        text = f"{importance_emoji} *{subject}* from *{sender_name}* to {recipient_list}"
+    else:
+        text = f"{importance_emoji} *{subject}* from *{sender_name}*"
 
     if not use_blocks:
         return (text, None)
@@ -383,9 +387,11 @@ def format_mcp_message_for_slack(
     )
 
     # Metadata section
+    recipient_lines = "\n".join(f"• {name}" for name in recipients) if recipients else "—"
+
     metadata_fields = [
-        {"type": "mrkdwn", "text": f"*From:*\n{sender_name}"},
-        {"type": "mrkdwn", "text": f"*To:*\n{', '.join(recipients[:5])}"},
+        {"type": "mrkdwn", "text": f"*From:*\n*{sender_name}*"},
+        {"type": "mrkdwn", "text": f"*To:*\n{recipient_lines}"},
     ]
 
     if message_id:


### PR DESCRIPTION
## Summary
- highlight Slack notifications with bold sender names and full recipient lists to match MCP Mail details
- include full routing information in fallback Slack text
- add regression test covering the new Slack formatting

## Testing
- uv run pytest tests/test_slack_mirror.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae35799e0832fb1347e977a24e4a7)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances Slack message formatting to show bold sender and complete recipient lists in fallback text and Block Kit, with a new test validating the full details.
> 
> - **Slack formatting (`src/mcp_agent_mail/slack_integration.py`)**:
>   - Fallback `text` now includes full routing: bold `sender_name` and comma-joined `recipients`.
>   - Metadata fields: `From` uses bold sender; `To` shows all recipients as a bulleted list; includes optional short `Message ID`.
> - **Tests (`tests/test_slack_mirror.py`)**:
>   - Add `test_format_mcp_message_for_slack_includes_full_agent_details` ensuring fallback text includes all recipients and blocks render bold sender and full bulleted recipients.
>   - Update imports to include `format_mcp_message_for_slack`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc2681eeca0cfcd0b7f6d7c38eb7b144355a9775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->