### PR TITLE
Disable writes to .mcp_mail directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ When an agent sends a message via `send_message`, here's what happens:
   
 **Configuration:**
 - Storage location: `STORAGE_ROOT` env var (default: `.mcp_mail`)
-  - **Project-local (default)**: `.mcp_mail` - messages stored in project directory and committed to Git
-  - **Optional project-key anchored**: set `STORAGE_PROJECT_KEY_ENABLED=true` to store under `<project_key>/.mcp_mail` (project_key must be the git repo root)
-  - **Disable local archive**: set `STORAGE_LOCAL_ARCHIVE_ENABLED=false` to require project-key storage; otherwise defaults to `.mcp_mail`
+  - **Project-local**: set `STORAGE_LOCAL_ARCHIVE_ENABLED=true` to store in `.mcp_mail` - messages stored in project directory and committed to Git
+  - **Project-key anchored**: set `STORAGE_PROJECT_KEY_ENABLED=true` to store under `<project_key>/.mcp_mail` (project_key must be the git repo root)
+  - **Default behavior**: Both storage modes disabled by default; must explicitly enable one to use MCP Agent Mail
   - **Global alternative**: `~/.mcp_agent_mail_git_mailbox_repo` - messages stored in user home directory
 - Git author: `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` env vars
 
@@ -1815,7 +1815,7 @@ result = await client.call_tool("list_extended_tools", {})
 | :-- | :-- | :-- |
 | `STORAGE_ROOT` | `.mcp_mail` | Root for per-project repos and SQLite DB (project-local by default) |
 | `STORAGE_PROJECT_KEY_ENABLED` | `false` | When true, use `<project_key>/.mcp_mail` as archive root (project_key must be git repo root) |
-| `STORAGE_LOCAL_ARCHIVE_ENABLED` | `true` | When false, disable default `.mcp_mail` archive; requires project-key storage |
+| `STORAGE_LOCAL_ARCHIVE_ENABLED` | `false` | When true, enable `.mcp_mail` archive; when false, requires project-key storage |
 | `HTTP_HOST` | `127.0.0.1` | Bind host for HTTP transport |
 | `HTTP_PORT` | `8765` | Bind port for HTTP transport |
 | `HTTP_PATH` | `/mcp/` | HTTP path where MCP endpoint is mounted |

--- a/src/mcp_agent_mail/config.py
+++ b/src/mcp_agent_mail/config.py
@@ -290,7 +290,7 @@ def get_settings() -> Settings:
         project_key_storage_enabled=_bool(
             _decouple_config("STORAGE_PROJECT_KEY_ENABLED", default="false"), default=False
         ),
-        local_archive_enabled=_bool(_decouple_config("STORAGE_LOCAL_ARCHIVE_ENABLED", default="true"), default=True),
+        local_archive_enabled=_bool(_decouple_config("STORAGE_LOCAL_ARCHIVE_ENABLED", default="false"), default=False),
         project_key_prompt_enabled=_bool(
             _decouple_config("STORAGE_PROJECT_KEY_PROMPT_ENABLED", default="true"), default=True
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ def isolated_env(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_TOOLS_MODE", "extended")
     storage_root = tmp_path / "storage"
     monkeypatch.setenv("STORAGE_ROOT", str(storage_root))
+    monkeypatch.setenv("STORAGE_LOCAL_ARCHIVE_ENABLED", "true")
     monkeypatch.setenv("GIT_AUTHOR_NAME", "test-agent")
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
     monkeypatch.setenv("INLINE_IMAGE_MAX_BYTES", "128")

--- a/tests/integration/test_default_mcp_mail_storage.py
+++ b/tests/integration/test_default_mcp_mail_storage.py
@@ -32,6 +32,7 @@ async def mcp_mail_storage(tmp_path, monkeypatch):
 
     # Configure environment to use .mcp_mail/ storage
     monkeypatch.setenv("STORAGE_ROOT", str(mcp_mail_dir))
+    monkeypatch.setenv("STORAGE_LOCAL_ARCHIVE_ENABLED", "true")
     monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{mcp_mail_dir}/storage.sqlite3")
     monkeypatch.setenv("GIT_AUTHOR_NAME", "test-agent")
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")

--- a/tests/integration/test_search_mailbox_mcp_mail.py
+++ b/tests/integration/test_search_mailbox_mcp_mail.py
@@ -40,6 +40,7 @@ async def mcp_mail_search_env(tmp_path, monkeypatch):
 
     # Configure environment to use .mcp_mail/ storage
     monkeypatch.setenv("STORAGE_ROOT", str(mcp_mail_dir))
+    monkeypatch.setenv("STORAGE_LOCAL_ARCHIVE_ENABLED", "true")
     monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{mcp_mail_dir}/storage.sqlite3")
     monkeypatch.setenv("GIT_AUTHOR_NAME", "test-agent")
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")

--- a/tests/integration/test_since_ts_filter.py
+++ b/tests/integration/test_since_ts_filter.py
@@ -36,6 +36,7 @@ async def mcp_mail_storage(tmp_path, monkeypatch):
 
     # Configure environment to use .mcp_mail/ storage
     monkeypatch.setenv("STORAGE_ROOT", str(mcp_mail_dir))
+    monkeypatch.setenv("STORAGE_LOCAL_ARCHIVE_ENABLED", "true")
     monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{mcp_mail_dir}/storage.sqlite3")
     monkeypatch.setenv("GIT_AUTHOR_NAME", "test-agent")
     monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")


### PR DESCRIPTION
Changes STORAGE_LOCAL_ARCHIVE_ENABLED default from true to false, requiring users to explicitly enable local archive storage.

This prevents unintended writes to .mcp_mail/ directories and enforces explicit storage mode selection (local vs project-key).

Changes:
- config.py: Change STORAGE_LOCAL_ARCHIVE_ENABLED default to false
- README.md: Update documentation to reflect new default behavior
- tests: Add STORAGE_LOCAL_ARCHIVE_ENABLED=true to test fixtures that rely on local storage

All storage-related integration tests pass with these changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Changes default `STORAGE_LOCAL_ARCHIVE_ENABLED` to `false`, updates README to require explicit storage mode selection, and adjusts tests to enable local archive where needed.
> 
> - **Config**:
>   - Default `STORAGE_LOCAL_ARCHIVE_ENABLED` set to `false` in `src/mcp_agent_mail/config.py`.
> - **Documentation**:
>   - README storage section rewritten to clarify explicit enablement of either project-local or project-key storage.
>   - Configuration table updated (`STORAGE_LOCAL_ARCHIVE_ENABLED` default now `false`).
> - **Tests**:
>   - Test fixtures and integration tests set `STORAGE_LOCAL_ARCHIVE_ENABLED=true` to use `.mcp_mail` during tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76bad209b02b32124ad79256dd218b502d53b34a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->