### PR TITLE
Thread Slack ack replies

### DIFF
--- a/docs/slack_bot_sync_design.md
+++ b/docs/slack_bot_sync_design.md
@@ -1,0 +1,44 @@
+# Slack Bot Bidirectional Sync Design
+
+This document describes the standard Slack **bot-based** integration that provides full bidirectional communication between Slack and MCP Agent Mail without relying on legacy outgoing webhooks.
+
+## Goals
+- **Inbound:** Turn Slack channel messages into MCP inbox messages with thread continuity.
+- **Outbound:** Post MCP messages back to Slack in the originating channel/thread when possible.
+- **Deduplication:** Avoid duplicate ingestion when Slack retries events.
+- **Security:** Enforce Slack signing-secret verification for Events API requests.
+
+## Architecture
+- Slack sends Events API payloads to `/slack/events` (validated with `SLACK_SIGNING_SECRET`).
+- The server normalizes events via `handle_slack_message_event`, deriving the MCP `thread_id` from the Slack channel + thread/message timestamp.
+- `_ingest_slack_bridge_message` creates the MCP message, writes the archive entry, and records dedupe keys.
+- When a Slack client is available (bot token connected), the ingestion step maps the MCP `thread_id` to the Slack channel/timestamp so future MCP replies post into the same Slack thread.
+- Outbound Slack notifications (`notify_slack_message` / `notify_slack_ack`) use the thread mapping to reply inline; otherwise they fall back to the configured default channel.
+
+## Configuration (env)
+```
+SLACK_ENABLED=true
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_SIGNING_SECRET=...
+SLACK_SYNC_ENABLED=true
+SLACK_SYNC_CHANNELS=C1234567890,C2345678901    # optional allowlist
+SLACK_SYNC_PROJECT_NAME=slack-sync
+SLACK_SYNC_THREAD_REPLIES=true
+SLACK_NOTIFY_ON_MESSAGE=true
+SLACK_DEFAULT_CHANNEL=C1234567890
+```
+
+## Setup Steps
+1. Create a Slack app with a bot user; add scopes `chat:write`, `chat:write.public`, `channels:history`, `channels:read`, and (optionally) `groups:history` if syncing private channels.
+2. Enable **Event Subscriptions**; set the Request URL to `<server>/slack/events` and subscribe to `message.channels` (and `message.groups` if needed).
+3. Install the app to the workspace, copy the bot token and signing secret, and place them in `.env` using the variables above.
+4. Restart the MCP Agent Mail server so the Slack client initializes with the bot token.
+
+## Runtime Behavior
+- A message in a synced channel becomes an MCP message with sender `SlackBridge` and subject `[Slack] <first line>`. The `thread_id` uses `slack_<channel>_<ts>` so threaded replies stay together.
+- If the Slack bot is available, the ingestion step maps that `thread_id` to the Slack channel/timestamp; when an agent replies from MCP, the Slack notification uses the mapping to reply in-thread instead of creating a new top-level post.
+- Deduplication uses `(channel, ts)` keys to drop Slack retry deliveries.
+
+## Notes
+- Slackbox (legacy outgoing webhook) remains available but is not required for bot-based bidirectional sync.
+- Thread mappings are in-memory; if you need persistence across restarts, extend `SlackClient.map_thread` to store mappings in the database.

--- a/docs/slackbox_design.md
+++ b/docs/slackbox_design.md
@@ -1,0 +1,45 @@
+# Slackbox Support Design
+
+## Goal
+Provide a minimal, webhook-only path for importing Slack channel chatter into MCP Agent Mail when a full Slack bot app is unavailable. Slackbox relies on Slack's legacy **Outgoing Webhooks/Slash Command style payloads** so users can forward channel posts to MCP mail with only a verification token and channel allowlist.
+
+## Requirements
+- **No bot token required:** Works even when `SLACK_BOT_TOKEN` is absent.
+- **Webhook verification:** Reject requests without the configured Slackbox token.
+- **Channel scoping:** Only ingest messages from allowed channels/IDs.
+- **Thread grouping:** Derive stable `thread_id` using channel + timestamp when provided.
+- **Subject hygiene:** Prefix subjects to differentiate Slackbox traffic and trim to MCP limits.
+- **Deduplication:** Reuse existing in-memory Slack event cache to drop duplicates from retries.
+- **Operational ergonomics:** Reuse the Slack sync project and synthetic `Slackbox` agent so inbox flows and archives match the existing Slack bridge.
+
+## Data Flow
+1. Slack posts an `application/x-www-form-urlencoded` payload (token, channel, user, text, timestamp) to `/slackbox/incoming`.
+2. The server verifies the token, checks allowed channels, and normalizes the text into an MCP message envelope:
+   - Sender: `Slackbox` (configurable)
+   - Subject: `[Slackbox] <first line>` (prefix configurable)
+   - Body: raw text with Slack mentions untouched
+   - Thread: `slackbox_<channel>_<timestamp>` when both are available
+3. The payload is ingested via the shared Slack bridge path that creates the Slackbridge agent (if needed), broadcasts to all active agents in the Slack sync project, writes to the archive, and records dedupe keys.
+
+## Configuration
+New environment flags (read via `SlackSettings`):
+
+- `SLACKBOX_ENABLED` (default `false`): turn Slackbox ingestion on.
+- `SLACKBOX_TOKEN`: verification token from the Slack outgoing webhook/slash command.
+- `SLACKBOX_CHANNELS`: comma-separated list of allowed channel IDs or names; empty means allow all.
+- `SLACKBOX_SENDER_NAME` (default `Slackbox`): synthetic agent name for ingested messages.
+- `SLACKBOX_SUBJECT_PREFIX` (default `[Slackbox]`): prepended to created subjects.
+
+Slackbox reuses `SLACK_SYNC_PROJECT_NAME` to choose the project that receives the messages.
+
+## Error Handling & Limits
+- 401 for invalid/missing token.
+- 503 when Slackbox is disabled or the Slack signing secret is missing for the main Slack app.
+- Empty texts short-circuit with a friendly 200 response to avoid noisy retries.
+- Dedupe cache prevents duplicate inserts on webhook retries using `(channel, timestamp)` keys when available.
+
+## Testing Strategy
+- Unit/integration tests for `/slackbox/incoming`:
+  - Token acceptance/rejection.
+  - Happy path creates a message with expected subject/prefix and thread grouping.
+  - Disallowed channel short-circuits without creating a message.

--- a/docs/slackbox_design.md
+++ b/docs/slackbox_design.md
@@ -34,7 +34,7 @@ Slackbox reuses `SLACK_SYNC_PROJECT_NAME` to choose the project that receives th
 
 ## Error Handling & Limits
 - 401 for invalid/missing token.
-- 503 when Slackbox is disabled or the Slack signing secret is missing for the main Slack app.
+- 503 when Slackbox is disabled or the Slackbox token is not configured.
 - Empty texts short-circuit with a friendly 200 response to avoid noisy retries.
 - Dedupe cache prevents duplicate inserts on webhook retries using `(channel, timestamp)` keys when available.
 

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -4669,6 +4669,7 @@ def build_mcp_server() -> FastMCP:
                             message_id=str(message.id),
                             agent_name=agent.name,
                             subject=message.subject,
+                            thread_id=message.thread_id,
                         )
 
                     task = asyncio.create_task(_send_ack_notification())

--- a/src/mcp_agent_mail/config.py
+++ b/src/mcp_agent_mail/config.py
@@ -134,6 +134,12 @@ class SlackSettings:
     use_blocks: bool  # Use Slack Block Kit for rich formatting
     include_attachments: bool  # Include MCP message attachments in Slack
     webhook_url: str | None  # Optional incoming webhook URL (legacy)
+    # Slackbox (legacy outgoing webhook ingestion)
+    slackbox_enabled: bool  # Accept Slack outgoing webhook payloads
+    slackbox_token: str | None  # Verification token from Slack outgoing webhook
+    slackbox_channels: list[str]  # Allowed channel IDs or names
+    slackbox_sender_name: str  # Name for the synthetic sender agent
+    slackbox_subject_prefix: str  # Prefix to apply to Slackbox-derived subjects
 
 
 @dataclass(slots=True, frozen=True)
@@ -349,6 +355,11 @@ def get_settings() -> Settings:
         use_blocks=_bool(_decouple_config("SLACK_USE_BLOCKS", default="true"), default=True),
         include_attachments=_bool(_decouple_config("SLACK_INCLUDE_ATTACHMENTS", default="true"), default=True),
         webhook_url=_decouple_config("SLACK_WEBHOOK_URL", default="") or None,
+        slackbox_enabled=_bool(_decouple_config("SLACKBOX_ENABLED", default="false"), default=False),
+        slackbox_token=_decouple_config("SLACKBOX_TOKEN", default="") or None,
+        slackbox_channels=_csv("SLACKBOX_CHANNELS", default=""),
+        slackbox_sender_name=_decouple_config("SLACKBOX_SENDER_NAME", default="Slackbox"),
+        slackbox_subject_prefix=_decouple_config("SLACKBOX_SUBJECT_PREFIX", default="[Slackbox]"),
     )
 
     def _agent_name_mode(value: str) -> str:

--- a/src/mcp_agent_mail/http.py
+++ b/src/mcp_agent_mail/http.py
@@ -1193,7 +1193,14 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
         form = await request.form()
 
         token = (form.get("token") or "").strip()
-        if settings.slack.slackbox_token and token != settings.slack.slackbox_token:
+        expected_token = (settings.slack.slackbox_token or "").strip()
+        if not expected_token:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Slackbox token not configured",
+            )
+
+        if token != expected_token:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Slackbox token")
 
         text = (form.get("text") or "").strip()

--- a/src/mcp_agent_mail/http.py
+++ b/src/mcp_agent_mail/http.py
@@ -938,6 +938,156 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
     async def oauth_meta_root_mcp() -> JSONResponse:
         return JSONResponse({"mcp_oauth": False})
 
+    async def _ingest_slack_bridge_message(
+        message_info: dict[str, Any],
+        *,
+        logger: structlog.stdlib.BoundLogger,
+        dedupe_key: tuple[str, str] | None = None,
+        source: str = "slack",
+    ) -> JSONResponse:
+        """Shared ingestion path for Slack-derived payloads."""
+        from .models import Agent
+
+        slack_ts = message_info.get("slack_ts")
+        slack_channel = message_info.get("slack_channel")
+        cache_key = dedupe_key or ((slack_channel, slack_ts) if slack_ts and slack_channel else None)
+
+        if cache_key and cache_key in _slack_event_cache:
+            logger.info(
+                "slack_message_duplicate_skipped",
+                slack_ts=slack_ts,
+                channel=slack_channel,
+                source=source,
+            )
+            return JSONResponse({"ok": True, "message": "Duplicate Slack event skipped"})
+
+        project = await _ensure_project(settings.slack.sync_project_name)
+
+        sender_name = message_info["sender_name"]
+        sender_agent = await _get_agent_by_name_optional(sender_name)
+
+        if not sender_agent:
+            async with get_session() as session:
+                sender_agent = Agent(
+                    name=sender_name,
+                    project_id=project.id,
+                    program="slack_bridge",
+                    model="slack-events",
+                    task_description="Bridges Slack messages into MCP Agent Mail",
+                    is_active=True,
+                )
+                session.add(sender_agent)
+                try:
+                    await session.commit()
+                    await session.refresh(sender_agent)
+                    logger.info("slack_bridge_agent_created", agent_name=sender_name)
+                except IntegrityError:
+                    await session.rollback()
+                    result = await session.execute(
+                        select(Agent).where(
+                            cast(Any, Agent.project_id) == project.id,
+                            cast(Any, Agent.name) == sender_name,
+                        )
+                    )
+                    existing_agent = result.scalars().first()
+                    if not existing_agent:
+                        raise
+                    sender_agent = existing_agent
+
+        async with get_session() as session:
+            result = await session.execute(
+                select(Agent).where(
+                    cast(Any, Agent.project_id) == project.id,
+                    cast(Any, Agent.is_active).is_(True),
+                    cast(Any, Agent.id) != sender_agent.id,
+                )
+            )
+            recipient_agents = list(result.scalars().all())
+
+        if not recipient_agents:
+            logger.warning("slack_no_recipients", project=project.slug, source=source)
+            return JSONResponse({"ok": True, "message": "No active recipients"})
+
+        recipients_list = [(agent, "to") for agent in recipient_agents]
+        message = await _create_message(
+            project=project,
+            sender=sender_agent,
+            subject=message_info["subject"],
+            body_md=message_info["body_md"],
+            recipients=recipients_list,
+            importance="normal",
+            ack_required=False,
+            thread_id=message_info.get("thread_id"),
+            attachments=[],
+        )
+
+        to_agents = [r[0] for r in recipients_list if r[1] == "to"]
+        cc_agents = [r[0] for r in recipients_list if r[1] == "cc"]
+        bcc_agents = [r[0] for r in recipients_list if r[1] == "bcc"]
+        frontmatter = _message_frontmatter(
+            message=message,
+            project=project,
+            sender=sender_agent,
+            to_agents=to_agents,
+            cc_agents=cc_agents,
+            bcc_agents=bcc_agents,
+            attachments=[],
+        )
+
+        async def _persist_archive() -> None:
+            try:
+                archive = await ensure_archive(settings, project.slug)
+                await write_message_bundle(
+                    archive=archive,
+                    message=frontmatter,
+                    body_md=message.body_md,
+                    sender=sender_agent.name,
+                    recipients=[agent.name for agent in recipient_agents],
+                    extra_paths=[],
+                )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.error("slack_archive_write_failed", error=str(exc), source=source)
+
+        _archive_task = asyncio.create_task(_persist_archive())
+        _ = _archive_task
+
+        if cache_key:
+            _slack_event_cache.add(cache_key)
+            _slack_event_cache_order.append(cache_key)
+            while len(_slack_event_cache_order) > _slack_event_cache_order.maxlen:
+                old = _slack_event_cache_order.popleft()
+                _slack_event_cache.discard(old)
+
+        slack_client_ref = None
+        try:
+            from .app import _slack_client as _global_slack_client
+
+            slack_client_ref = _global_slack_client
+        except Exception:
+            slack_client_ref = None
+
+        slack_thread_ts = message_info.get("slack_thread_ts") or message_info.get("slack_ts")
+        slack_channel_id = message_info.get("slack_channel")
+        if slack_client_ref and message_info.get("thread_id") and slack_thread_ts and slack_channel_id:
+            try:
+                await slack_client_ref.map_thread(
+                    mcp_thread_id=message_info["thread_id"],
+                    slack_channel_id=slack_channel_id,
+                    slack_thread_ts=slack_thread_ts,
+                )
+            except Exception as exc:
+                logger.warning("slack_thread_map_failed", error=str(exc), source=source)
+
+        logger.info(
+            "slack_message_ingested",
+            message_id=message.id,
+            thread_id=message.thread_id,
+            slack_ts=slack_ts,
+            source=source,
+        )
+
+        return JSONResponse({"ok": True, "message": "Message created"})
+
     # Slack Events API webhook endpoint for bidirectional sync
     @fastapi_app.post("/slack/events")
     async def slack_events_webhook(request: Request) -> JSONResponse:
@@ -952,7 +1102,6 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
         Reference: https://api.slack.com/apis/connections/events-api
         """
         logger = structlog.get_logger("slack")
-        from .models import Agent
 
         if not settings.slack.enabled:
             raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Slack integration disabled")
@@ -1005,175 +1154,23 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
 
             # Handle message events
             if event_subtype == "message":
-                # Import handler function
                 from .slack_integration import handle_slack_message_event
 
-                # Process Slack message and get MCP message details
                 message_info = await handle_slack_message_event(event, settings)
 
                 if message_info:
-                    # Idempotency: skip duplicates on slack_ts + channel (best-effort, in-memory)
                     slack_ts = message_info.get("slack_ts")
                     slack_channel = message_info.get("slack_channel")
-                    if slack_ts and slack_channel:
-                        key = (slack_channel, slack_ts)
-                        if key in _slack_event_cache:
-                            logger.info(
-                                "slack_message_duplicate_skipped",
-                                slack_ts=slack_ts,
-                                channel=slack_channel,
-                            )
-                            return JSONResponse({"ok": True, "message": "Duplicate Slack event skipped"})
+                    dedupe_key = (slack_channel, slack_ts) if slack_ts and slack_channel else None
 
-                    # Create MCP message from Slack event
-                    try:
-                        # Ensure project exists
-                        project = await _ensure_project(settings.slack.sync_project_name)
+                    return await _ingest_slack_bridge_message(
+                        message_info,
+                        logger=logger,
+                        dedupe_key=dedupe_key,
+                        source="slack_events",
+                    )
 
-                        # Get or create SlackBridge agent
-                        sender_name = message_info["sender_name"]
-                        sender_agent = await _get_agent_by_name_optional(sender_name)
-
-                        if not sender_agent:
-                            # Auto-create SlackBridge system agent; tolerate concurrent creation
-                            async with get_session() as session:
-                                sender_agent = Agent(
-                                    name=sender_name,
-                                    project_id=project.id,
-                                    program="slack_bridge",
-                                    model="slack-events",
-                                    task_description="Bridges Slack messages into MCP Agent Mail",
-                                    is_active=True,
-                                )
-                                session.add(sender_agent)
-                                try:
-                                    await session.commit()
-                                    await session.refresh(sender_agent)
-                                    logger.info("slack_bridge_agent_created", agent_name=sender_name)
-                                except IntegrityError:
-                                    await session.rollback()
-                                    result = await session.execute(
-                                        select(Agent).where(
-                                            cast(Any, Agent.project_id) == project.id,
-                                            cast(Any, Agent.name) == sender_name,
-                                        )
-                                    )
-                                    existing_agent = result.scalars().first()
-                                    if not existing_agent:
-                                        raise
-                                    sender_agent = existing_agent
-
-                        # Get all active agents as recipients (broadcast)
-                        async with get_session() as session:
-                            result = await session.execute(
-                                select(Agent).where(
-                                    cast(Any, Agent.project_id) == project.id,
-                                    cast(Any, Agent.is_active).is_(True),
-                                    cast(Any, Agent.id) != sender_agent.id,  # Don't send to self
-                                )
-                            )
-                            recipient_agents = list(result.scalars().all())
-
-                        if not recipient_agents:
-                            logger.warning("slack_no_recipients", project=project.slug)
-                            return JSONResponse({"ok": True, "message": "No active recipients"})
-
-                        # Create message
-                        recipients_list = [(agent, "to") for agent in recipient_agents]
-                        message = await _create_message(
-                            project=project,
-                            sender=sender_agent,
-                            subject=message_info["subject"],
-                            body_md=message_info["body_md"],
-                            recipients=recipients_list,
-                            importance="normal",
-                            ack_required=False,
-                            thread_id=message_info.get("thread_id"),
-                            attachments=[],
-                        )
-
-                        # Write message to archive in background to avoid webhook timeout
-                        to_agents = [r[0] for r in recipients_list if r[1] == "to"]
-                        cc_agents = [r[0] for r in recipients_list if r[1] == "cc"]
-                        bcc_agents = [r[0] for r in recipients_list if r[1] == "bcc"]
-                        frontmatter = _message_frontmatter(
-                            message=message,
-                            project=project,
-                            sender=sender_agent,
-                            to_agents=to_agents,
-                            cc_agents=cc_agents,
-                            bcc_agents=bcc_agents,
-                            attachments=[],
-                        )
-
-                        async def _persist_archive() -> None:
-                            try:
-                                archive = await ensure_archive(settings, project.slug)
-                                await write_message_bundle(
-                                    archive=archive,
-                                    message=frontmatter,
-                                    body_md=message.body_md,
-                                    sender=sender_agent.name,
-                                    recipients=[agent.name for agent in recipient_agents],
-                                    extra_paths=[],
-                                )
-                            except Exception as exc:
-                                logger.error("slack_archive_write_failed", error=str(exc))
-
-                        _archive_task = asyncio.create_task(_persist_archive())
-                        _ = _archive_task
-
-                        # Record dedupe key after successful creation
-                        if slack_ts and slack_channel:
-                            key = (slack_channel, slack_ts)
-                            _slack_event_cache.add(key)
-                            _slack_event_cache_order.append(key)
-                            # Trim cache if over capacity (deque handles oldest eviction)
-                            while len(_slack_event_cache_order) > _slack_event_cache_order.maxlen:
-                                old = _slack_event_cache_order.popleft()
-                                _slack_event_cache.discard(old)
-
-                        # Capture thread mapping so outbound replies stay in the same Slack thread
-                        slack_client_ref = None
-                        try:
-                            from .app import _slack_client as _global_slack_client  # lazy import to avoid cycles
-
-                            slack_client_ref = _global_slack_client
-                        except Exception:
-                            slack_client_ref = None
-
-                        if (
-                            slack_client_ref
-                            and message_info.get("thread_id")
-                            and message_info.get("slack_thread_ts")
-                            and message_info.get("slack_channel")
-                        ):
-                            try:
-                                await slack_client_ref.map_thread(
-                                    mcp_thread_id=message_info["thread_id"],
-                                    slack_channel_id=message_info["slack_channel"],
-                                    slack_thread_ts=message_info["slack_thread_ts"],
-                                )
-                            except Exception as exc:  # best-effort; do not block ingestion
-                                logger.warning("slack_thread_map_failed", error=str(exc))
-
-                        logger.info(
-                            "slack_message_created",
-                            message_id=message.id,
-                            subject=message.subject[:50],
-                            recipients=len(recipient_agents),
-                        )
-
-                        return JSONResponse({"ok": True, "message_id": str(message.id)})
-
-                    except Exception as e:
-                        logger.error("slack_message_creation_failed", error=str(e))
-                        raise HTTPException(
-                            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to create message: {e}"
-                        ) from e
-                else:
-                    # Message was filtered/ignored (e.g., bot message, wrong channel)
-                    return JSONResponse({"ok": True, "message": "Event ignored"})
+                return JSONResponse({"ok": True, "message": "Event ignored"})
 
             # Handle reaction_added events (future: map to acknowledgments)
             elif event_subtype == "reaction_added":
@@ -1183,6 +1180,56 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
 
         # Return success for unhandled event types
         return JSONResponse({"ok": True})
+
+    @fastapi_app.post("/slackbox/incoming")
+    async def slackbox_incoming(request: Request) -> JSONResponse:
+        """Handle legacy Slack outgoing webhook payloads (Slackbox)."""
+
+        logger = structlog.get_logger("slackbox")
+
+        if not settings.slack.slackbox_enabled:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Slackbox disabled")
+
+        form = await request.form()
+
+        token = (form.get("token") or "").strip()
+        if settings.slack.slackbox_token and token != settings.slack.slackbox_token:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Slackbox token")
+
+        text = (form.get("text") or "").strip()
+        if not text:
+            return JSONResponse({"ok": True, "message": "No text provided"})
+
+        channel_id = (form.get("channel_id") or form.get("channel_name") or "").strip()
+        if settings.slack.slackbox_channels and channel_id not in settings.slack.slackbox_channels:
+            logger.info("slackbox_channel_skipped", channel=channel_id)
+            return JSONResponse({"ok": True, "message": "Channel not allowed"})
+
+        timestamp = (form.get("timestamp") or form.get("ts") or "").strip()
+        dedupe_key = (channel_id, timestamp) if channel_id and timestamp else None
+
+        subject_line = text.split("\n", 1)[0].strip() or "Slackbox message"
+        subject_prefixed = f"{settings.slack.slackbox_subject_prefix} {subject_line}".strip()
+        subject = subject_prefixed[:120]
+
+        thread_id = f"slackbox_{channel_id}_{timestamp}" if channel_id and timestamp else None
+
+        message_info = {
+            "sender_name": settings.slack.slackbox_sender_name,
+            "subject": subject,
+            "body_md": text,
+            "thread_id": thread_id,
+            "slack_channel": channel_id,
+            "slack_ts": timestamp,
+            "slack_thread_ts": timestamp,
+        }
+
+        return await _ingest_slack_bridge_message(
+            message_info,
+            logger=logger,
+            dedupe_key=dedupe_key,
+            source="slackbox",
+        )
 
     # A minimal stateless ASGI adapter that does not rely on ASGI lifespan management
     # and runs a fresh StreamableHTTP transport per request.

--- a/src/mcp_agent_mail/slack_integration.py
+++ b/src/mcp_agent_mail/slack_integration.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 # Regex pattern for extracting Slack user mentions (e.g., <@U123|name>)
 _SLACK_MENTION_PATTERN = re.compile(r"<@([A-Z0-9]+)(?:\|[^>]+)?>")
 # Thread id format: slack_<channel_id>_<thread_ts> or slackbox_<channel_id>_<thread_ts>
-_SLACK_THREAD_ID_PATTERN = re.compile(r"^(?:slackbox|slack)_([^_]+)_(.+)$")
+_SLACK_THREAD_ID_PATTERN = re.compile(r"^(?:slackbox|slack)_(.+)_([^_]+)$")
 
 
 @dataclass

--- a/src/mcp_agent_mail/slack_integration.py
+++ b/src/mcp_agent_mail/slack_integration.py
@@ -40,6 +40,8 @@ logger = logging.getLogger(__name__)
 
 # Regex pattern for extracting Slack user mentions (e.g., <@U123|name>)
 _SLACK_MENTION_PATTERN = re.compile(r"<@([A-Z0-9]+)(?:\|[^>]+)?>")
+# Thread id format: slack_<channel_id>_<thread_ts>
+_SLACK_THREAD_ID_PATTERN = re.compile(r"^slack_([^_]+)_(.+)$")
 
 
 @dataclass
@@ -474,6 +476,12 @@ async def notify_slack_message(
             if thread_mapping:
                 slack_thread_ts = thread_mapping.slack_thread_ts
                 channel = thread_mapping.slack_channel_id
+            else:
+                match = _SLACK_THREAD_ID_PATTERN.match(thread_key)
+                if match:
+                    derived_channel, derived_ts = match.groups()
+                    slack_thread_ts = derived_ts
+                    channel = derived_channel
 
         # Post to Slack
         response = await client.post_message(
@@ -505,6 +513,7 @@ async def notify_slack_ack(
     message_id: str,
     agent_name: str,
     subject: str,
+    thread_id: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     """Send a notification to Slack when a message is acknowledged.
 
@@ -532,10 +541,32 @@ async def notify_slack_ack(
 
     try:
         text = f":white_check_mark: {agent_name} acknowledged: {subject}"
+
+        channel = settings.slack.default_channel
+        slack_thread_ts: Optional[str] = None
+        thread_key = thread_id or message_id
+
+        if thread_key:
+            thread_mapping = await client.get_slack_thread(thread_key)
+            if thread_mapping:
+                slack_thread_ts = thread_mapping.slack_thread_ts
+                channel = thread_mapping.slack_channel_id
+            else:
+                match = _SLACK_THREAD_ID_PATTERN.match(thread_key)
+                if match:
+                    channel, slack_thread_ts = match.groups()
+
         response = await client.post_message(
-            channel=settings.slack.default_channel,
+            channel=channel,
             text=text,
+            thread_ts=slack_thread_ts,
         )
+
+        if thread_key and not slack_thread_ts:
+            msg_ts = response.get("ts")
+            channel_id = response.get("channel")
+            if msg_ts and channel_id:
+                await client.map_thread(thread_key, channel_id, msg_ts)
 
         logger.info(f"Sent Slack ack notification for message {message_id[:8]}")
         return response
@@ -632,7 +663,7 @@ async def handle_slack_message_event(
         "thread_id": mcp_thread_id,
         "slack_channel": channel_id,
         "slack_ts": message_ts,
-        "slack_thread_ts": thread_ts,
+        "slack_thread_ts": thread_ts or message_ts,
         "mentioned_users": mentioned_users,
     }
 

--- a/src/mcp_agent_mail/slack_integration.py
+++ b/src/mcp_agent_mail/slack_integration.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 
 # Regex pattern for extracting Slack user mentions (e.g., <@U123|name>)
 _SLACK_MENTION_PATTERN = re.compile(r"<@([A-Z0-9]+)(?:\|[^>]+)?>")
-# Thread id format: slack_<channel_id>_<thread_ts>
-_SLACK_THREAD_ID_PATTERN = re.compile(r"^slack_([^_]+)_(.+)$")
+# Thread id format: slack_<channel_id>_<thread_ts> or slackbox_<channel_id>_<thread_ts>
+_SLACK_THREAD_ID_PATTERN = re.compile(r"^(?:slackbox|slack)_([^_]+)_(.+)$")
 
 
 @dataclass
@@ -554,7 +554,9 @@ async def notify_slack_ack(
             else:
                 match = _SLACK_THREAD_ID_PATTERN.match(thread_key)
                 if match:
-                    channel, slack_thread_ts = match.groups()
+                    derived_channel, derived_ts = match.groups()
+                    channel = derived_channel
+                    slack_thread_ts = derived_ts
 
         response = await client.post_message(
             channel=channel,

--- a/tests/integration/test_slack_webhook_api.py
+++ b/tests/integration/test_slack_webhook_api.py
@@ -211,11 +211,13 @@ async def test_notify_slack_message_replies_into_slack_thread(monkeypatch):
             thread_ts: str | None = None,
             mrkdwn: bool = True,
         ) -> dict[str, str | None]:
-            self.calls.append({
-                "channel": channel,
-                "text": text,
-                "thread_ts": thread_ts,
-            })
+            self.calls.append(
+                {
+                    "channel": channel,
+                    "text": text,
+                    "thread_ts": thread_ts,
+                }
+            )
             return {"ok": True, "ts": thread_ts, "channel": channel}
 
     monkeypatch.setenv("SLACK_ENABLED", "1")

--- a/tests/integration/test_slackbox_webhook_api.py
+++ b/tests/integration/test_slackbox_webhook_api.py
@@ -84,3 +84,16 @@ async def test_slackbox_requires_configured_token(monkeypatch):
         )
 
     assert resp.status_code == 503
+
+
+def test_slackbox_thread_pattern_allows_underscore_channel_names():
+    from mcp_agent_mail.slack_integration import _SLACK_THREAD_ID_PATTERN
+
+    thread_id = "slackbox_my_channel_1111.2222"
+    match = _SLACK_THREAD_ID_PATTERN.match(thread_id)
+
+    assert match is not None
+    channel, ts = match.groups()
+
+    assert channel == "my_channel"
+    assert ts == "1111.2222"

--- a/tests/integration/test_slackbox_webhook_api.py
+++ b/tests/integration/test_slackbox_webhook_api.py
@@ -1,0 +1,65 @@
+import httpx
+import pytest
+from sqlalchemy import desc, select
+
+from mcp_agent_mail.config import get_settings
+from mcp_agent_mail.db import ensure_schema, get_session
+from mcp_agent_mail.http import build_http_app
+from mcp_agent_mail.models import Message
+
+
+@pytest.mark.asyncio
+async def test_slackbox_incoming_creates_message(monkeypatch):
+    monkeypatch.setenv("SLACK_ENABLED", "1")
+    monkeypatch.setenv("SLACKBOX_ENABLED", "1")
+    monkeypatch.setenv("SLACKBOX_TOKEN", "slackbox-token")
+    monkeypatch.setenv("SLACKBOX_CHANNELS", "CCHAN123")
+    monkeypatch.setenv("SLACK_SYNC_PROJECT_NAME", "slackbox-project")
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    settings = get_settings()
+    app = build_http_app(settings)
+    await ensure_schema()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/slackbox/incoming",
+            data={
+                "token": "slackbox-token",
+                "channel_id": "CCHAN123",
+                "text": "Slackbox hello world",
+                "timestamp": "1111.2222",
+            },
+        )
+
+    assert resp.status_code == 200
+
+    async with get_session() as session:
+        result = await session.execute(select(Message).order_by(desc(Message.id)).limit(1))
+        message = result.scalars().first()
+
+    assert message is not None
+    assert settings.slack.slackbox_subject_prefix in (message.subject or "")
+    assert message.thread_id == "slackbox_CCHAN123_1111.2222"
+
+
+@pytest.mark.asyncio
+async def test_slackbox_rejects_invalid_token(monkeypatch):
+    monkeypatch.setenv("SLACK_ENABLED", "1")
+    monkeypatch.setenv("SLACKBOX_ENABLED", "1")
+    monkeypatch.setenv("SLACKBOX_TOKEN", "expected-token")
+
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    settings = get_settings()
+    app = build_http_app(settings)
+    await ensure_schema()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/slackbox/incoming",
+            data={"token": "wrong", "text": "hi"},
+        )
+
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- send Slack acknowledgment notifications into the originating threads using existing mappings or parsed thread ids, and map new threads when needed
- propagate message thread ids into the Slack ack notifier so replies stay with their Slack conversations
- add an integration test covering the thread-id fallback path for Slack acknowledgment notifications

## Testing
- uv run pytest tests/integration/test_slack_webhook_api.py -q --disable-warnings --no-cov
- uv run pytest tests/integration/test_slackbox_webhook_api.py -q --disable-warnings --no-cov
- uv run pytest -q --disable-warnings --no-cov *(fails: two agent discovery UX tests; run interrupted afterward)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ae48ec30c832f90d74d04eee050c5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Slackbox webhook ingestion and thread-aware Slack notifications/mapping via a shared Slack ingestion path, with new config, docs, and integration tests.
> 
> - **Backend (Slack integration)**
>   - Introduce shared `_ingest_slack_bridge_message` used by `/slack/events` and new `/slackbox/incoming`.
>   - Add Slackbox webhook endpoint `POST /slackbox/incoming` with token validation, channel allowlist, dedupe, and `thread_id`=`slackbox_<channel>_<ts>`.
>   - Update `/slack/events` message flow to use shared ingestion and dedupe key; record Slack thread mapping when available.
>   - Pass `message.thread_id` into `notify_slack_ack` so acks reply in-thread.
> - **Slack client/notifications**
>   - Add `_SLACK_THREAD_ID_PATTERN` and fallback to derive `(channel, ts)` from `thread_id` for posting replies into originating Slack threads.
>   - `notify_slack_message`/`notify_slack_ack` now thread-aware (use mapping or parsed `thread_id`; map new threads when needed).
>   - `handle_slack_message_event` ensures `slack_thread_ts` defaults to `thread_ts` or `ts`.
> - **Config**
>   - Extend `SlackSettings` with Slackbox options: `slackbox_enabled`, `slackbox_token`, `slackbox_channels`, `slackbox_sender_name`, `slackbox_subject_prefix`.
> - **Docs**
>   - Add `docs/slack_bot_sync_design.md` and `docs/slackbox_design.md` describing architecture, configuration, and behavior.
> - **Tests**
>   - Integration tests for Slack thread mapping, thread-aware notifications, Slackbox endpoint (token checks, thread_id format), and mapping for top-level events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c36f0546e30f4d1aa276c36fbc28203b6674888. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Slack bidirectional synchronization with thread continuity for inbound and outbound messages
  * Legacy Slack webhook integration support with enhanced configuration options
  * Thread-aware message routing for Slack notifications

* **Documentation**
  * Added comprehensive design documentation for Slack integration architecture and setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->