### PR TITLE
Harden Slackbox token checks and clarify docs

### DIFF
--- a/docs/slackbox_design.md
+++ b/docs/slackbox_design.md
@@ -34,7 +34,7 @@ Slackbox reuses `SLACK_SYNC_PROJECT_NAME` to choose the project that receives th
 
 ## Error Handling & Limits
 - 401 for invalid/missing token.
-- 503 when Slackbox is disabled or the Slack signing secret is missing for the main Slack app.
+- 503 when Slackbox is disabled.
 - Empty texts short-circuit with a friendly 200 response to avoid noisy retries.
 - Dedupe cache prevents duplicate inserts on webhook retries using `(channel, timestamp)` keys when available.
 

--- a/src/mcp_agent_mail/http.py
+++ b/src/mcp_agent_mail/http.py
@@ -1190,10 +1190,16 @@ def build_http_app(settings: Settings, server=None) -> FastAPI:
         if not settings.slack.slackbox_enabled:
             raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Slackbox disabled")
 
+        if not settings.slack.slackbox_token:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Slackbox token not configured",
+            )
+
         form = await request.form()
 
         token = (form.get("token") or "").strip()
-        if settings.slack.slackbox_token and token != settings.slack.slackbox_token:
+        if token != settings.slack.slackbox_token:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Slackbox token")
 
         text = (form.get("text") or "").strip()

--- a/src/mcp_agent_mail/slack_integration.py
+++ b/src/mcp_agent_mail/slack_integration.py
@@ -554,7 +554,9 @@ async def notify_slack_ack(
             else:
                 match = _SLACK_THREAD_ID_PATTERN.match(thread_key)
                 if match:
-                    channel, slack_thread_ts = match.groups()
+                    derived_channel, derived_ts = match.groups()
+                    channel = derived_channel
+                    slack_thread_ts = derived_ts
 
         response = await client.post_message(
             channel=channel,


### PR DESCRIPTION
## Summary
- enforce Slackbox token configuration and validation before processing webhook payloads
- align Slack thread ID parsing variable assignment order with notification logic for clarity
- update Slackbox design documentation to match implemented error handling

## Testing
- uv run pytest tests/integration/test_slackbox_webhook_api.py -q --disable-warnings --no-cov

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc3e6324c832f9dd416d576815518)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require configured Slackbox token with strict 401/503 handling, align Slack thread ID parsing assignment, and update docs accordingly.
> 
> - **Backend**:
>   - **`src/mcp_agent_mail/http.py`** (`/slackbox/incoming`):
>     - Require `SLACKBOX_TOKEN` to be configured; return `503` if missing.
>     - Always validate token; return `401` on mismatch.
>     - Keep `503` when Slackbox is disabled.
>   - **`src/mcp_agent_mail/slack_integration.py`**:
>     - Normalize thread ID parsing assignment when deriving `channel` and `thread_ts` from `thread_id`.
> - **Docs**:
>   - **`docs/slackbox_design.md`**: Clarify error handling to `503` when Slackbox is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a70ae22a82e720d28d68f15e52c16cb653626fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->