### PR TITLE
Guard archive writes when archive disabled

### DIFF
--- a/src/mcp_agent_mail/storage.py
+++ b/src/mcp_agent_mail/storage.py
@@ -32,8 +32,12 @@ _IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<path>[^)]+)\)")
 def is_archive_enabled(settings: Settings) -> bool:
     """Check if archive storage is enabled (either local or project-key based).
 
-    Archive storage is optional - SQLite database always works regardless of this setting.
-    Archive is used for git-based file storage of messages as .md files.
+    Archive storage is optional for some core features (for example, basic
+    project and agent registration), which can operate using the SQLite
+    database alone. However, many higher-level application operations
+    (such as message archiving and related Git-backed workflows) still
+    require archive storage to be enabled and will call :func:`ensure_archive`.
+    Archive is used for Git-based file storage of messages as .md files.
     """
     return settings.storage.local_archive_enabled or settings.storage.project_key_storage_enabled
 


### PR DESCRIPTION
## Summary
- add `ensure_archive_if_enabled` helper and reuse it to avoid repeated archive checks
- gate agent lifecycle archive writes so archive-disabled configurations no longer error
- update tool and helper docs to clarify when archive storage is optional

## Testing
- uv run ruff check --fix --unsafe-fixes
- uvx ty check src/mcp_agent_mail/app.py src/mcp_agent_mail/storage.py *(fails: existing SQLAlchemy typing diagnostics remain)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69431233039c832f807b1e1e56a890b4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `ensure_archive_if_enabled` and use it to conditionally skip Git archive writes; clarify docs on when archive storage is optional.
> 
> - **Core/Archive Handling**
>   - Add `ensure_archive_if_enabled(settings, project)` helper to return `ProjectArchive | None`.
>   - Replace direct `ensure_archive(...)` calls with conditional archive writes across agent lifecycle paths (`_get_or_create_agent`, `_create_placeholder_agent`, `_delete_agent`, `_retire_agent`).
> - **Tools/Behavior**
>   - `ensure_project` and `register_agent`: initialize/write to archive only when enabled; otherwise proceed without Git persistence.
> - **Docs/Comments**
>   - Update docstrings to emphasize archive storage is optional for basic registration but required for Git-backed workflows.
>   - Refine wording around archive initialization and idempotency in `ensure_project` and `register_agent`.
> - **Storage**
>   - Clarify `is_archive_enabled` docstring about optional vs required operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a639fba6b1e8b9b9bc4e758ab2f6a64ca6bff0f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->