### PR TITLE
Add message mode selector (Normal/Think/God) to compose interface

### DIFF
--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -168,11 +168,11 @@
                  id="subject"
                  x-model="subject"
                  required
-                 maxlength="200"
+                 :maxlength="getSubjectMaxLength()"
                  placeholder="e.g., Urgent: Review security vulnerability"
                  class="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white placeholder-slate-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all" />
           <p class="mt-1.5 text-xs text-slate-500 dark:text-slate-500">
-            <span x-text="getSubjectWithMode().length"></span> / 200 characters
+            <span x-text="subject.length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
             <span x-show="messageMode !== 'normal'" class="text-slate-400">(including mode prefix)</span>
           </p>
         </div>
@@ -533,6 +533,12 @@ function overseerComposer() {
       }
 
       return rawSubject;
+    },
+
+    getSubjectMaxLength() {
+      const rawSubject = this.subject.trim();
+      const prefixLength = Math.max(this.getSubjectWithMode().length - rawSubject.length, 0);
+      return 200 - prefixLength;
     },
 
     insertMarkdown(before, after, placeholder) {

--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -172,8 +172,8 @@
                  placeholder="e.g., Urgent: Review security vulnerability"
                  class="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white placeholder-slate-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all" />
           <p class="mt-1.5 text-xs text-slate-500 dark:text-slate-500">
-            <span x-text="getSubjectWithMode().length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
-            <span x-show="messageMode !== 'normal'" class="text-slate-400">(including mode prefix)</span>
+            <span x-text="subject.length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
+            <span x-show="messageMode !== 'normal'" class="text-slate-400">(mode reserves space for prefix)</span>
           </p>
         </div>
 
@@ -459,6 +459,8 @@ function overseerComposer() {
     viewMode: 'write',
     renderedPreview: '',
     messageMode: 'normal',
+    thinkPrefix: ':THINK:',
+    godPrefix: ':GOD:',
     sending: false,
     showToast: false,
     showConfirmModal: false,
@@ -505,33 +507,31 @@ function overseerComposer() {
     getSubjectWithMode() {
       // Prepend mode indicator to subject based on selected mode, avoiding duplicate prefixes
       const rawSubject = this.subject.trim();
-      const thinkPrefix = ':THINK:';
-      const godPrefix = ':GOD:';
 
       if (this.messageMode === 'think') {
         // If subject already starts with :THINK:, return as-is
-        if (rawSubject.startsWith(thinkPrefix)) {
+        if (rawSubject.startsWith(this.thinkPrefix)) {
           return rawSubject;
         }
         // If subject starts with :GOD:, replace it with :THINK:
-        if (rawSubject.startsWith(godPrefix)) {
-          const remainder = rawSubject.slice(godPrefix.length).trimStart();
-          return thinkPrefix + (remainder ? ' ' + remainder : '');
+        if (rawSubject.startsWith(this.godPrefix)) {
+          const remainder = rawSubject.slice(this.godPrefix.length).trimStart();
+          return this.thinkPrefix + (remainder ? ' ' + remainder : '');
         }
         // Otherwise, prepend :THINK:
-        return thinkPrefix + (rawSubject ? ' ' + rawSubject : '');
+        return this.thinkPrefix + (rawSubject ? ' ' + rawSubject : '');
       } else if (this.messageMode === 'god') {
         // If subject already starts with :GOD:, return as-is
-        if (rawSubject.startsWith(godPrefix)) {
+        if (rawSubject.startsWith(this.godPrefix)) {
           return rawSubject;
         }
         // If subject starts with :THINK:, replace it with :GOD:
-        if (rawSubject.startsWith(thinkPrefix)) {
-          const remainder = rawSubject.slice(thinkPrefix.length).trimStart();
-          return godPrefix + (remainder ? ' ' + remainder : '');
+        if (rawSubject.startsWith(this.thinkPrefix)) {
+          const remainder = rawSubject.slice(this.thinkPrefix.length).trimStart();
+          return this.godPrefix + (remainder ? ' ' + remainder : '');
         }
         // Otherwise, prepend :GOD:
-        return godPrefix + (rawSubject ? ' ' + rawSubject : '');
+        return this.godPrefix + (rawSubject ? ' ' + rawSubject : '');
       }
 
       return rawSubject;
@@ -539,21 +539,29 @@ function overseerComposer() {
 
     getSubjectMaxLength() {
       const rawSubject = this.subject.trim();
-      const thinkPrefix = ':THINK:';
-      const godPrefix = ':GOD:';
 
       if (this.messageMode === 'think') {
-        if (rawSubject.startsWith(thinkPrefix)) {
+        if (rawSubject.startsWith(this.thinkPrefix)) {
           return 200;
         }
-        return 200 - 8;
+        // If it starts with the OTHER prefix, account for the replacement
+        if (rawSubject.startsWith(this.godPrefix)) {
+          // It will replace :GOD: (6) with :THINK: (8), net +2
+          return 200 - (8 - 6); // 198
+        }
+        return 200 - 8; // 192
       }
 
       if (this.messageMode === 'god') {
-        if (rawSubject.startsWith(godPrefix)) {
+        if (rawSubject.startsWith(this.godPrefix)) {
           return 200;
         }
-        return 200 - 6;
+        // If it starts with the OTHER prefix, account for the replacement
+        if (rawSubject.startsWith(this.thinkPrefix)) {
+          // It will replace :THINK: (8) with :GOD: (6), net -2
+          return 200 + (8 - 6); // 202
+        }
+        return 200 - 6; // 194
       }
 
       return 200;

--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -176,6 +176,50 @@
           </p>
         </div>
 
+        <!-- Message Mode Selector -->
+        <div>
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+            Message Mode
+          </label>
+          <div class="flex items-center gap-4">
+            <label class="flex items-center gap-2 cursor-pointer group">
+              <input type="radio"
+                     name="messageMode"
+                     value="normal"
+                     x-model="messageMode"
+                     class="w-4 h-4 text-primary-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 focus:ring-2 focus:ring-primary-500" />
+              <span class="text-sm text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
+                Normal
+              </span>
+            </label>
+            <label class="flex items-center gap-2 cursor-pointer group">
+              <input type="radio"
+                     name="messageMode"
+                     value="think"
+                     x-model="messageMode"
+                     class="w-4 h-4 text-primary-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 focus:ring-2 focus:ring-primary-500" />
+              <span class="text-sm text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
+                Think/Plan
+              </span>
+            </label>
+            <label class="flex items-center gap-2 cursor-pointer group">
+              <input type="radio"
+                     name="messageMode"
+                     value="god"
+                     x-model="messageMode"
+                     class="w-4 h-4 text-primary-600 bg-white dark:bg-slate-700 border-slate-300 dark:border-slate-600 focus:ring-2 focus:ring-primary-500" />
+              <span class="text-sm text-slate-700 dark:text-slate-300 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
+                God Mode
+              </span>
+            </label>
+          </div>
+          <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+            <span x-show="messageMode === 'normal'">Standard message - no special indicator</span>
+            <span x-show="messageMode === 'think'">Adds <code class="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs font-mono">:THINK:</code> prefix to help agents identify planning/thinking requests</span>
+            <span x-show="messageMode === 'god'">Adds <code class="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs font-mono">:GOD:</code> prefix for maximum priority directives</span>
+          </p>
+        </div>
+
         <!-- Message Body -->
         <div x-show="viewMode === 'write' || viewMode === 'split'" x-transition>
           <label for="body" class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
@@ -362,7 +406,17 @@ Please investigate the following:
           </div>
           <div class="flex items-start justify-between text-sm gap-3">
             <span class="text-slate-600 dark:text-slate-400 flex-shrink-0">Subject:</span>
-            <span class="font-medium text-slate-900 dark:text-white text-right" x-text="subject"></span>
+            <span class="font-medium text-slate-900 dark:text-white text-right" x-text="getSubjectWithMode()"></span>
+          </div>
+          <div class="flex items-center justify-between text-sm">
+            <span class="text-slate-600 dark:text-slate-400">Mode:</span>
+            <span class="px-2 py-0.5 text-xs font-medium rounded"
+                  :class="{
+                    'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300': messageMode === 'normal',
+                    'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400': messageMode === 'think',
+                    'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400': messageMode === 'god'
+                  }"
+                  x-text="messageMode === 'normal' ? 'Normal' : messageMode === 'think' ? 'Think/Plan' : 'God Mode'"></span>
           </div>
           <div class="flex items-center justify-between text-sm">
             <span class="text-slate-600 dark:text-slate-400">Priority:</span>
@@ -403,6 +457,7 @@ function overseerComposer() {
     recipientSearch: '',
     viewMode: 'write',
     renderedPreview: '',
+    messageMode: 'normal',
     sending: false,
     showToast: false,
     showConfirmModal: false,
@@ -441,6 +496,17 @@ function overseerComposer() {
              this.body.trim() &&
              this.body.length <= 49600 &&
              !this.sending;
+    },
+
+    getSubjectWithMode() {
+      // Append mode indicator to subject based on selected mode
+      const subject = this.subject.trim();
+      if (this.messageMode === 'think') {
+        return ':THINK: ' + subject;
+      } else if (this.messageMode === 'god') {
+        return ':GOD: ' + subject;
+      }
+      return subject;
     },
 
     insertMarkdown(before, after, placeholder) {
@@ -524,7 +590,7 @@ function overseerComposer() {
           },
           body: JSON.stringify({
             recipients: this.selectedRecipients,
-            subject: this.subject.trim(),
+            subject: this.getSubjectWithMode(),
             body_md: this.body.trim(),
             thread_id: this.threadId.trim() || null,
           })

--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -172,7 +172,7 @@
                  placeholder="e.g., Urgent: Review security vulnerability"
                  class="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white placeholder-slate-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all" />
           <p class="mt-1.5 text-xs text-slate-500 dark:text-slate-500">
-            <span x-text="subject.length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
+            <span x-text="getSubjectWithMode().length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
             <span x-show="messageMode !== 'normal'" class="text-slate-400">(including mode prefix)</span>
           </p>
         </div>
@@ -515,7 +515,8 @@ function overseerComposer() {
         }
         // If subject starts with :GOD:, replace it with :THINK:
         if (rawSubject.startsWith(godPrefix)) {
-          return thinkPrefix + rawSubject.slice(godPrefix.length);
+          const remainder = rawSubject.slice(godPrefix.length).trimStart();
+          return thinkPrefix + (remainder ? ' ' + remainder : '');
         }
         // Otherwise, prepend :THINK:
         return thinkPrefix + (rawSubject ? ' ' + rawSubject : '');
@@ -526,7 +527,8 @@ function overseerComposer() {
         }
         // If subject starts with :THINK:, replace it with :GOD:
         if (rawSubject.startsWith(thinkPrefix)) {
-          return godPrefix + rawSubject.slice(thinkPrefix.length);
+          const remainder = rawSubject.slice(thinkPrefix.length).trimStart();
+          return godPrefix + (remainder ? ' ' + remainder : '');
         }
         // Otherwise, prepend :GOD:
         return godPrefix + (rawSubject ? ' ' + rawSubject : '');
@@ -537,8 +539,24 @@ function overseerComposer() {
 
     getSubjectMaxLength() {
       const rawSubject = this.subject.trim();
-      const prefixLength = Math.max(this.getSubjectWithMode().length - rawSubject.length, 0);
-      return 200 - prefixLength;
+      const thinkPrefix = ':THINK:';
+      const godPrefix = ':GOD:';
+
+      if (this.messageMode === 'think') {
+        if (rawSubject.startsWith(thinkPrefix)) {
+          return 200;
+        }
+        return 200 - 8;
+      }
+
+      if (this.messageMode === 'god') {
+        if (rawSubject.startsWith(godPrefix)) {
+          return 200;
+        }
+        return 200 - 6;
+      }
+
+      return 200;
     },
 
     insertMarkdown(before, after, placeholder) {

--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -172,16 +172,17 @@
                  placeholder="e.g., Urgent: Review security vulnerability"
                  class="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white placeholder-slate-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all" />
           <p class="mt-1.5 text-xs text-slate-500 dark:text-slate-500">
-            <span x-text="subject.length"></span> / 200 characters
+            <span x-text="getSubjectWithMode().length"></span> / 200 characters
+            <span x-show="messageMode !== 'normal'" class="text-slate-400">(including mode prefix)</span>
           </p>
         </div>
 
         <!-- Message Mode Selector -->
-        <div>
-          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
+        <fieldset>
+          <legend class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-3">
             Message Mode
-          </label>
-          <div class="flex items-center gap-4">
+          </legend>
+          <div class="flex items-center gap-4" role="group" aria-describedby="messageMode-help">
             <label class="flex items-center gap-2 cursor-pointer group">
               <input type="radio"
                      name="messageMode"
@@ -213,12 +214,12 @@
               </span>
             </label>
           </div>
-          <p class="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          <p id="messageMode-help" class="mt-2 text-xs text-slate-500 dark:text-slate-400">
             <span x-show="messageMode === 'normal'">Standard message - no special indicator</span>
             <span x-show="messageMode === 'think'">Adds <code class="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs font-mono">:THINK:</code> prefix to help agents identify planning/thinking requests</span>
             <span x-show="messageMode === 'god'">Adds <code class="px-1 py-0.5 bg-slate-200 dark:bg-slate-700 rounded text-xs font-mono">:GOD:</code> prefix for maximum priority directives</span>
           </p>
-        </div>
+        </fieldset>
 
         <!-- Message Body -->
         <div x-show="viewMode === 'write' || viewMode === 'split'" x-transition>
@@ -489,24 +490,49 @@ function overseerComposer() {
     },
 
     canSend() {
+      // Calculate the final subject length including mode prefix
+      const finalSubjectLength = this.getSubjectWithMode().length;
+
       return this.selectedRecipients.length > 0 &&
              this.selectedRecipients.length <= 100 &&
              this.subject.trim() &&
-             this.subject.length <= 200 &&
+             finalSubjectLength <= 200 &&
              this.body.trim() &&
              this.body.length <= 49600 &&
              !this.sending;
     },
 
     getSubjectWithMode() {
-      // Append mode indicator to subject based on selected mode
-      const subject = this.subject.trim();
+      // Prepend mode indicator to subject based on selected mode, avoiding duplicate prefixes
+      const rawSubject = this.subject.trim();
+      const thinkPrefix = ':THINK:';
+      const godPrefix = ':GOD:';
+
       if (this.messageMode === 'think') {
-        return ':THINK: ' + subject;
+        // If subject already starts with :THINK:, return as-is
+        if (rawSubject.startsWith(thinkPrefix)) {
+          return rawSubject;
+        }
+        // If subject starts with :GOD:, replace it with :THINK:
+        if (rawSubject.startsWith(godPrefix)) {
+          return thinkPrefix + rawSubject.slice(godPrefix.length);
+        }
+        // Otherwise, prepend :THINK:
+        return thinkPrefix + (rawSubject ? ' ' + rawSubject : '');
       } else if (this.messageMode === 'god') {
-        return ':GOD: ' + subject;
+        // If subject already starts with :GOD:, return as-is
+        if (rawSubject.startsWith(godPrefix)) {
+          return rawSubject;
+        }
+        // If subject starts with :THINK:, replace it with :GOD:
+        if (rawSubject.startsWith(thinkPrefix)) {
+          return godPrefix + rawSubject.slice(thinkPrefix.length);
+        }
+        // Otherwise, prepend :GOD:
+        return godPrefix + (rawSubject ? ' ' + rawSubject : '');
       }
-      return subject;
+
+      return rawSubject;
     },
 
     insertMarkdown(before, after, placeholder) {


### PR DESCRIPTION
## Summary
Added a new "Message Mode" feature to the email compose interface that allows users to select between three message modes: Normal, Think/Plan, and God Mode. Each mode automatically prepends a special indicator to the message subject to help agents identify the type of request.

## Key Changes
- **Message Mode Selector UI**: Added radio button group with three options (Normal, Think/Plan, God Mode) with descriptive help text for each mode
- **Mode Indicators**: 
  - Normal: No prefix (standard message)
  - Think/Plan: Prepends `:THINK:` to subject
  - God Mode: Prepends `:GOD:` to subject
- **Confirmation Modal**: Updated the send confirmation dialog to display the selected mode with color-coded badges (slate for normal, blue for think, purple for god)
- **Subject Preview**: Modified subject display in confirmation to show the final subject with mode prefix via new `getSubjectWithMode()` method
- **API Integration**: Updated the send request to use `getSubjectWithMode()` instead of raw subject, ensuring the mode indicator is included in the actual sent message

## Implementation Details
- Used Alpine.js `x-model` binding for reactive mode selection
- Added `messageMode` data property initialized to 'normal'
- Implemented `getSubjectWithMode()` helper method that conditionally prepends mode indicators
- Styled mode badges in confirmation modal with appropriate color schemes for dark/light modes
- Help text dynamically updates based on selected mode using `x-show` directives

https://claude.ai/code/session_013v341NHcTKqZL9xKnZH62W

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes confined to the compose template; risk is mainly around subject-length edge cases affecting send eligibility or server-side 200-char validation.
> 
> **Overview**
> Adds a **Message Mode** selector to `overseer_compose.html` (Normal / Think-Plan / God Mode) that prepends `:THINK:` or `:GOD:` to the subject and prevents duplicate/competing prefixes.
> 
> Updates client-side validation and UI to account for prefix-reserved subject length (dynamic `maxlength`, updated character counter), shows the mode and final subject in the send confirmation modal, and sends `subject` via `getSubjectWithMode()` instead of the raw trimmed subject.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe5694a45cfa0c71617883dc3a54714e197774c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message mode selection (Normal, Think/Plan, God Mode) in the composer UI with contextual help.
  * Mode selection prepends a mode indicator to the subject while avoiding duplicate prefixes.
  * Subject length display and validation now adapt dynamically to the active mode.
  * Confirmation panel shows a visual mode badge; sent messages include the mode-aware subject.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->