### PR TITLE
Enforce global agent namespace and cross-project messaging

### DIFF
--- a/tests/test_cross_project_messaging.py
+++ b/tests/test_cross_project_messaging.py
@@ -1,0 +1,162 @@
+"""Tests that agents in different projects can message each other.
+
+Projects are informational labels (e.g., repo paths). They do NOT isolate agents —
+any agent can message any other agent regardless of project_key.
+"""
+from __future__ import annotations
+
+import pytest
+from fastmcp import Client
+
+from mcp_agent_mail.app import build_mcp_server
+
+
+def _extract_result(call_result):
+    """Extract the actual data from a CallToolResult."""
+    if hasattr(call_result, "structured_content") and call_result.structured_content:
+        return call_result.structured_content.get("result", call_result.data)
+    return call_result.data
+
+
+def _get(field: str, obj):
+    """Get field from dict or object."""
+    if isinstance(obj, dict):
+        return obj.get(field)
+    return getattr(obj, field, None)
+
+
+@pytest.mark.asyncio
+async def test_cross_project_messaging(isolated_env):
+    """Agents in different projects can message each other."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": "project-a"})
+        await client.call_tool("ensure_project", {"human_key": "project-b"})
+
+        await client.call_tool(
+            "register_agent",
+            {"project_key": "project-a", "program": "test", "model": "test", "name": "Alice"},
+        )
+        await client.call_tool(
+            "register_agent",
+            {"project_key": "project-b", "program": "test", "model": "test", "name": "Bob"},
+        )
+
+        # Alice (project-a) sends to Bob (project-b)
+        result = await client.call_tool(
+            "send_message",
+            {
+                "project_key": "project-a",
+                "sender_name": "Alice",
+                "to": ["Bob"],
+                "subject": "Cross-project hello",
+                "body_md": "Hi from project A!",
+            },
+        )
+        data = _extract_result(result)
+        deliveries = data.get("deliveries") if isinstance(data, dict) else getattr(data, "deliveries", [])
+        assert deliveries, "send_message should return deliveries"
+        assert len(deliveries) > 0, "Message should have at least one delivery"
+
+        # Bob (project-b) sees the message in his inbox
+        inbox = await client.call_tool(
+            "fetch_inbox",
+            {
+                "project_key": "project-b",
+                "agent_name": "Bob",
+                "limit": 10,
+            },
+        )
+        messages = _extract_result(inbox)
+        assert len(messages) == 1, f"Bob should have 1 message, got {len(messages)}"
+        assert _get("subject", messages[0]) == "Cross-project hello"
+
+
+@pytest.mark.asyncio
+async def test_cross_project_fetch_inbox_any_project_key(isolated_env):
+    """fetch_inbox works regardless of which project_key is passed — agents are global."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": "proj-sender"})
+        await client.call_tool("ensure_project", {"human_key": "proj-receiver"})
+
+        await client.call_tool(
+            "register_agent",
+            {"project_key": "proj-sender", "program": "test", "model": "test", "name": "Sender"},
+        )
+        await client.call_tool(
+            "register_agent",
+            {"project_key": "proj-receiver", "program": "test", "model": "test", "name": "Receiver"},
+        )
+
+        await client.call_tool(
+            "send_message",
+            {
+                "project_key": "proj-sender",
+                "sender_name": "Sender",
+                "to": ["Receiver"],
+                "subject": "Test delivery",
+                "body_md": "body",
+            },
+        )
+
+        # Fetch using sender's project_key — should still find Receiver's message
+        inbox = await client.call_tool(
+            "fetch_inbox",
+            {
+                "project_key": "proj-sender",
+                "agent_name": "Receiver",
+                "limit": 10,
+            },
+        )
+        messages = _extract_result(inbox)
+        assert len(messages) == 1, "Receiver should see the message regardless of project_key used in fetch"
+
+
+@pytest.mark.asyncio
+async def test_cross_project_reply(isolated_env):
+    """An agent can reply to a message from an agent in a different project."""
+    server = build_mcp_server()
+    async with Client(server) as client:
+        await client.call_tool("ensure_project", {"human_key": "reply-proj-a"})
+        await client.call_tool("ensure_project", {"human_key": "reply-proj-b"})
+
+        await client.call_tool(
+            "register_agent",
+            {"project_key": "reply-proj-a", "program": "test", "model": "test", "name": "Sprout"},
+        )
+        await client.call_tool(
+            "register_agent",
+            {"project_key": "reply-proj-b", "program": "test", "model": "test", "name": "Fern"},
+        )
+
+        # Sprout sends to Fern across projects
+        send_result = await client.call_tool(
+            "send_message",
+            {
+                "project_key": "reply-proj-a",
+                "sender_name": "Sprout",
+                "to": ["Fern"],
+                "subject": "Hello Fern",
+                "body_md": "Can you reply?",
+            },
+        )
+        send_data = _extract_result(send_result)
+        deliveries = send_data.get("deliveries") if isinstance(send_data, dict) else getattr(send_data, "deliveries", [])
+        mid = deliveries[0]["payload"]["id"]
+
+        # Fern replies from project-b — should work cross-project
+        reply_result = await client.call_tool(
+            "reply_message",
+            {
+                "project_key": "reply-proj-b",
+                "message_id": mid,
+                "sender_name": "Fern",
+                "body_md": "Sure, here's my reply!",
+            },
+        )
+        reply_data = _extract_result(reply_result)
+        thread_id = reply_data.get("thread_id") if isinstance(reply_data, dict) else getattr(reply_data, "thread_id", None)
+        deliveries_reply = reply_data.get("deliveries") if isinstance(reply_data, dict) else getattr(reply_data, "deliveries", [])
+        assert thread_id, "Reply should have thread_id"
+        assert deliveries_reply, "Reply should have deliveries"

--- a/tests/test_cross_project_messaging.py
+++ b/tests/test_cross_project_messaging.py
@@ -146,6 +146,7 @@ async def test_cross_project_reply(isolated_env):
         deliveries = (
             send_data.get("deliveries") if isinstance(send_data, dict) else getattr(send_data, "deliveries", [])
         )
+        assert deliveries, "send_message should return deliveries"
         mid = deliveries[0]["payload"]["id"]
 
         # Fern replies from project-b — should work cross-project

--- a/tests/test_cross_project_messaging.py
+++ b/tests/test_cross_project_messaging.py
@@ -3,6 +3,7 @@
 Projects are informational labels (e.g., repo paths). They do NOT isolate agents —
 any agent can message any other agent regardless of project_key.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -142,7 +143,9 @@ async def test_cross_project_reply(isolated_env):
             },
         )
         send_data = _extract_result(send_result)
-        deliveries = send_data.get("deliveries") if isinstance(send_data, dict) else getattr(send_data, "deliveries", [])
+        deliveries = (
+            send_data.get("deliveries") if isinstance(send_data, dict) else getattr(send_data, "deliveries", [])
+        )
         mid = deliveries[0]["payload"]["id"]
 
         # Fern replies from project-b — should work cross-project
@@ -156,7 +159,11 @@ async def test_cross_project_reply(isolated_env):
             },
         )
         reply_data = _extract_result(reply_result)
-        thread_id = reply_data.get("thread_id") if isinstance(reply_data, dict) else getattr(reply_data, "thread_id", None)
-        deliveries_reply = reply_data.get("deliveries") if isinstance(reply_data, dict) else getattr(reply_data, "deliveries", [])
+        thread_id = (
+            reply_data.get("thread_id") if isinstance(reply_data, dict) else getattr(reply_data, "thread_id", None)
+        )
+        deliveries_reply = (
+            reply_data.get("deliveries") if isinstance(reply_data, dict) else getattr(reply_data, "deliveries", [])
+        )
         assert thread_id, "Reply should have thread_id"
         assert deliveries_reply, "Reply should have deliveries"

--- a/tests/test_global_agent_uniqueness_modes.py
+++ b/tests/test_global_agent_uniqueness_modes.py
@@ -201,11 +201,7 @@ async def test_agent_names_strict_mode_raises_errors(isolated_env, monkeypatch):
 
         # Verify the error is about the name being taken globally
         error_msg = str(exc_info.value).lower()
-        assert (
-            "already in use" in error_msg
-            or "name_taken" in error_msg
-            or "exists in another project" in error_msg
-        )
+        assert "already in use" in error_msg or "name_taken" in error_msg or "exists in another project" in error_msg
 
 
 @pytest.mark.asyncio

--- a/tests/test_global_agent_uniqueness_modes.py
+++ b/tests/test_global_agent_uniqueness_modes.py
@@ -201,7 +201,11 @@ async def test_agent_names_strict_mode_raises_errors(isolated_env, monkeypatch):
 
         # Verify the error is about the name being taken globally
         error_msg = str(exc_info.value).lower()
-        assert "already in use" in error_msg or "name_taken" in error_msg
+        assert (
+            "already in use" in error_msg
+            or "name_taken" in error_msg
+            or "exists in another project" in error_msg
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
This PR removes project-based agent isolation and establishes a truly global agent namespace. Projects are now purely informational metadata labels (e.g., repo paths, team names) that do not restrict agent visibility or messaging. Any agent can message any other agent regardless of which project they are registered in.

## Key Changes

- **Global Agent Lookup**: Modified `_get_agent()` and `_get_agent_optional()` to look up agents by name globally, ignoring project boundaries. The `project_key` parameter is retained for API compatibility but no longer filters results.

- **Cross-Project Messaging**: Agents in different projects can now send messages to each other seamlessly. The backend queries agents and messages by global identifiers, not project-scoped ones.

- **Updated Error Messages**: Changed conflict error message from "Agent name is already in use" to "Agent exists in another project. Use force_reclaim=True to reassign" to clarify that projects don't isolate agents.

- **Documentation Updates**: 
  - Added comprehensive section in README explaining projects as metadata-only labels with cross-project messaging examples
  - Added critical note about `DATABASE_URL` requiring absolute paths for multi-workspace setups to ensure all agents share the same database
  - Updated docstrings in `register_agent()` and `_get_agent()` to clarify project semantics

- **Comprehensive Test Coverage**: Added `test_cross_project_messaging.py` with three new test cases:
  - `test_cross_project_messaging`: Verifies agents in different projects can message each other
  - `test_cross_project_fetch_inbox_any_project_key`: Confirms inbox fetching works regardless of which project_key is used
  - `test_cross_project_reply`: Validates reply functionality across project boundaries

- **Test Updates**: Updated existing test assertions to accept new error message wording.

## Implementation Details

The core change is in `src/mcp_agent_mail/app.py`:
- `_get_agent()` now delegates to `_get_agent_by_name()` which queries globally
- `_get_agent_optional()` similarly uses global lookup via `_get_agent_by_name_optional()`
- Project parameter is preserved in function signatures for backward compatibility but is not used in WHERE clauses

This ensures that message delivery, inbox fetching, and agent registration all operate on a unified global namespace while preserving project metadata for organizational context.

https://claude.ai/code/session_01B15MWwpJNtxCPopmu97yhZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core identity lookup semantics from project-scoped to global, which can impact routing and any assumptions about project isolation. File-reservation queries now rely primarily on `agent_id`, increasing the blast radius if ids/names are mis-associated across projects.
> 
> **Overview**
> Clarifies and enforces that `project_key` is *metadata only* for agent identity and messaging: `_get_agent()`/`_get_agent_optional()` now resolve agents globally by name, and `register_agent` conflict errors/docs are updated to reflect cross-project reclaim semantics.
> 
> Adjusts file-reservation operations to no longer require a matching `project_id` for release/renew (and relaxes the “not found for project” error), and adds new integration tests (`test_cross_project_messaging.py`) covering cross-project `send_message`, `fetch_inbox`, and `reply_message` flows. README is updated with explicit global-architecture guidance and a `DATABASE_URL` pitfall note for multi-workspace deployments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9114921a9de4fd812ebe0c946cb2695f9ef00851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now have globally unique names across projects, enabling cross-project messaging and global inbox visibility.

* **Improvements**
  * Registration/conflict errors clarified with guidance and a reclaim hint when a name exists elsewhere; project assignment treated as metadata.

* **Documentation**
  * README expanded with global-by-default architecture, cross-project examples, storage/deployment notes, and troubleshooting tips.

* **Tests**
  * Added end-to-end tests covering cross-project messaging, inbox visibility, replies, and name-uniqueness modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- COPILOT_TRACKING_START -->
## Copilot Review Tracking

| Comment ID | Author | File | Severity | Status | Summary |
|-----------|--------|------|----------|--------|---------|
| #2830562414 | cursor[bot] | `src/mcp_agent_mail/app.py:1918` | BLOCKING | **Fixed** | Global agent lookup + project-scoped reservation queries caused silent failures. Removed `FileReservation.project_id == project.id` from release/renew/force-release functions; now filtering only on `agent_id`. Commit 9114921. |
| coderabbit-144 | coderabbitai[bot] | `tests/test_cross_project_messaging.py:144` | IMPORTANT | **Fixed** | Added `assert deliveries` guard before `deliveries[0]` in `test_cross_project_reply` to prevent IndexError on silent send failure. Commit 9114921. |
| #3930590633 | greptile-apps[bot] | `src/mcp_agent_mail/app.py:1929` | STYLE | **Fixed** | Refactored `_get_agent_by_name` to delegate to `_get_agent_by_name_optional`, eliminating duplicate DB query block. Commit 9114921. |
| #2830532883 | greptile-apps[bot] | `tests/test_cross_project_messaging.py:26` | IMPORTANT | **Deferred** | Centralizing helpers to conftest.py requires modifying 6+ test files outside PR scope. |
| #2830541273 | greptile-apps[bot] | `tests/test_cross_project_messaging.py:26` | IMPORTANT | **Deferred** | Duplicate of #2830532883 - same conftest.py recommendation, same scope issue. |

**Run stats:** 3 fixed (1 BLOCKING, 1 IMPORTANT, 1 STYLE), 2 deferred | Commit: `9114921`
<!-- COPILOT_TRACKING_END -->
