### PR TITLE
Fix mode-prefixed subject length handling and counter/spacing in overseer composer

### DIFF
--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -172,8 +172,8 @@
                  placeholder="e.g., Urgent: Review security vulnerability"
                  class="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white placeholder-slate-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all" />
           <p class="mt-1.5 text-xs text-slate-500 dark:text-slate-500">
-            <span x-text="subject.length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
-            <span x-show="messageMode !== 'normal'" class="text-slate-400">(including mode prefix)</span>
+            <span x-text="getSubjectWithMode().length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
+            <span x-show="messageMode !== 'normal'" class="text-slate-400">(includes mode prefix)</span>
           </p>
         </div>
 
@@ -515,7 +515,8 @@ function overseerComposer() {
         }
         // If subject starts with :GOD:, replace it with :THINK:
         if (rawSubject.startsWith(godPrefix)) {
-          return thinkPrefix + rawSubject.slice(godPrefix.length);
+          const remainder = rawSubject.slice(godPrefix.length).trimStart();
+          return thinkPrefix + (remainder ? ' ' + remainder : '');
         }
         // Otherwise, prepend :THINK:
         return thinkPrefix + (rawSubject ? ' ' + rawSubject : '');
@@ -526,7 +527,8 @@ function overseerComposer() {
         }
         // If subject starts with :THINK:, replace it with :GOD:
         if (rawSubject.startsWith(thinkPrefix)) {
-          return godPrefix + rawSubject.slice(thinkPrefix.length);
+          const remainder = rawSubject.slice(thinkPrefix.length).trimStart();
+          return godPrefix + (remainder ? ' ' + remainder : '');
         }
         // Otherwise, prepend :GOD:
         return godPrefix + (rawSubject ? ' ' + rawSubject : '');
@@ -537,8 +539,38 @@ function overseerComposer() {
 
     getSubjectMaxLength() {
       const rawSubject = this.subject.trim();
-      const prefixLength = Math.max(this.getSubjectWithMode().length - rawSubject.length, 0);
-      return 200 - prefixLength;
+      const thinkPrefix = ':THINK:';
+      const godPrefix = ':GOD:';
+      const remainderAfterPrefix = (prefix) => rawSubject.slice(prefix.length).trimStart();
+      const replacementDelta = (fromPrefix, toPrefix) => {
+        const remainder = remainderAfterPrefix(fromPrefix);
+        const finalLength = toPrefix.length + (remainder ? 1 + remainder.length : 0);
+        return finalLength - rawSubject.length;
+      };
+
+      if (this.messageMode === 'think') {
+        if (rawSubject.startsWith(thinkPrefix)) {
+          return 200;
+        }
+        if (rawSubject.startsWith(godPrefix)) {
+          const delta = replacementDelta(godPrefix, thinkPrefix);
+          return 200 - Math.max(delta, 0);
+        }
+        return 200 - (thinkPrefix.length + 1);
+      }
+
+      if (this.messageMode === 'god') {
+        if (rawSubject.startsWith(godPrefix)) {
+          return 200;
+        }
+        if (rawSubject.startsWith(thinkPrefix)) {
+          const delta = replacementDelta(thinkPrefix, godPrefix);
+          return 200 - Math.max(delta, 0);
+        }
+        return 200 - (godPrefix.length + 1);
+      }
+
+      return 200;
     },
 
     insertMarkdown(before, after, placeholder) {


### PR DESCRIPTION
### Motivation
- Reviewers reported that the mode prefix (":THINK:" / ":GOD:") could cause the final subject to exceed the server 200‑char limit and produce a 400 error.  
- The helper could double‑prefix subjects and could produce inconsistent spacing when replacing prefixes.  
- The subject character counter and maxlength UI were misleading because they did not reflect the final prefixed subject.

### Description
- Updated `src/mcp_agent_mail/templates/overseer_compose.html` to show the actual prefixed subject length by using `getSubjectWithMode().length` in the character counter and clarified the helper text to "(includes mode prefix)".  
- Made `getSubjectWithMode()` idempotent and normalized spacing when replacing prefixes so inputs like `:GOD:Hello` become `:THINK: Hello` (not `:THINK:Hello`) and avoid duplicate prefixes.  
- Reworked `getSubjectMaxLength()` to account for the mode prefix (including the separating space) and handle prefix→prefix replacement deltas so the input `:maxlength` correctly prevents constructing an overlong final subject.  
- Committed the fix as `Fix mode subject length edge cases [codex-automation-commit]` and opened a PR titled "Fix mode-prefixed subject length handling" containing the changes.

### Testing
- Ran project pre-commit checks which executed `ruff check --fix --unsafe-fixes` and `uvx ty check`; both completed successfully.  
- Pre-commit reported Bandit findings (warnings) and a dependency vulnerability check could not be completed; these are non‑blocking and were not changed by this PR.  
- Attempted to start the UI server via the recommended background command, but the expected local path `/Users/jleechan/mcp_agent_mail` was not present in this environment so a live UI screenshot was not captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b9e03f924832fa0275589414f96df)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to subject prefixing/maxlength calculations; main risk is minor off-by-one/edge-case behavior affecting client-side validation and display.
> 
> **Overview**
> Fixes the Human Overseer composer’s subject handling when `:THINK:`/`:GOD:` mode prefixes are used so the client-side counter and `maxlength` reflect the *final* prefixed subject length and prevent constructing subjects that exceed the 200-char server limit.
> 
> Makes `getSubjectWithMode()` normalize spacing when replacing an existing prefix (e.g., ensuring a single space after the prefix) and reworks `getSubjectMaxLength()` to correctly account for prefix addition vs. prefix-to-prefix replacement deltas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e91ae53f3fd6eb3d66af12e3bd95a0b366a53eea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->