### PR TITLE
Fix mode-prefixed subject length handling and counter/spacing in overseer composer

### DIFF
--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -158,6 +158,36 @@
         </div>
       </div>
 
+      <!-- Message Mode Selector -->
+      <div class="px-6 py-3 bg-slate-50 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700">
+        <div class="flex items-center gap-3">
+          <span class="text-sm font-medium text-slate-700 dark:text-slate-300">Message Mode:</span>
+          <div class="flex items-center gap-1 p-0.5 bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
+            <button type="button" @click="messageMode = 'normal'"
+                    class="px-3 py-1.5 text-xs font-medium rounded-md transition-all flex items-center gap-1.5"
+                    :class="messageMode === 'normal' ? 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 shadow-sm' : 'text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'">
+              <i data-lucide="message-square" class="w-3.5 h-3.5"></i>
+              Normal
+            </button>
+            <button type="button" @click="messageMode = 'think'"
+                    class="px-3 py-1.5 text-xs font-medium rounded-md transition-all flex items-center gap-1.5"
+                    :class="messageMode === 'think' ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 shadow-sm' : 'text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'">
+              <i data-lucide="brain" class="w-3.5 h-3.5"></i>
+              Think
+            </button>
+            <button type="button" @click="messageMode = 'god'"
+                    class="px-3 py-1.5 text-xs font-medium rounded-md transition-all flex items-center gap-1.5"
+                    :class="messageMode === 'god' ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 shadow-sm' : 'text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'">
+              <i data-lucide="sparkles" class="w-3.5 h-3.5"></i>
+              God
+            </button>
+          </div>
+          <span x-show="messageMode !== 'normal'" class="text-xs text-slate-500 dark:text-slate-400">
+            <span x-text="messageMode === 'think' ? '🤔 AI will reason step-by-step' : '🌟 AI will use enhanced capabilities'"></span>
+          </span>
+        </div>
+      </div>
+
       <div class="p-6 space-y-4">
         <!-- Subject Line -->
         <div>
@@ -403,6 +433,7 @@ function overseerComposer() {
     threadId: '',
     recipientSearch: '',
     viewMode: 'write',
+    messageMode: 'normal',
     renderedPreview: '',
     sending: false,
     showToast: false,

--- a/src/mcp_agent_mail/templates/overseer_compose.html
+++ b/src/mcp_agent_mail/templates/overseer_compose.html
@@ -168,11 +168,12 @@
                  id="subject"
                  x-model="subject"
                  required
-                 maxlength="200"
+                 :maxlength="getSubjectMaxLength()"
                  placeholder="e.g., Urgent: Review security vulnerability"
                  class="w-full px-4 py-2.5 bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-900 dark:text-white placeholder-slate-400 focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-all" />
           <p class="mt-1.5 text-xs text-slate-500 dark:text-slate-500">
-            <span x-text="subject.length"></span> / 200 characters
+            <span x-text="getSubjectWithMode().length"></span> / <span x-text="getSubjectMaxLength()"></span> characters
+            <span x-show="messageMode !== 'normal'" class="text-slate-400">(includes mode prefix)</span>
           </p>
         </div>
 
@@ -442,6 +443,78 @@ function overseerComposer() {
              this.body.length <= 49600 &&
              !this.sending;
     },
+
+    getSubjectWithMode() {
+      // Prepend mode indicator to subject based on selected mode, avoiding duplicate prefixes
+      const rawSubject = this.subject.trim();
+      const thinkPrefix = ':THINK:';
+      const godPrefix = ':GOD:';
+
+      if (this.messageMode === 'think') {
+        // If subject already starts with :THINK:, return as-is
+        if (rawSubject.startsWith(thinkPrefix)) {
+          return rawSubject;
+        }
+        // If subject starts with :GOD:, replace it with :THINK:
+        if (rawSubject.startsWith(godPrefix)) {
+          const remainder = rawSubject.slice(godPrefix.length).trimStart();
+          return thinkPrefix + (remainder ? ' ' + remainder : '');
+        }
+        // Otherwise, prepend :THINK:
+        return thinkPrefix + (rawSubject ? ' ' + rawSubject : '');
+      } else if (this.messageMode === 'god') {
+        // If subject already starts with :GOD:, return as-is
+        if (rawSubject.startsWith(godPrefix)) {
+          return rawSubject;
+        }
+        // If subject starts with :THINK:, replace it with :GOD:
+        if (rawSubject.startsWith(thinkPrefix)) {
+          const remainder = rawSubject.slice(thinkPrefix.length).trimStart();
+          return godPrefix + (remainder ? ' ' + remainder : '');
+        }
+        // Otherwise, prepend :GOD:
+        return godPrefix + (rawSubject ? ' ' + rawSubject : '');
+      }
+
+      return rawSubject;
+    },
+
+    getSubjectMaxLength() {
+      const rawSubject = this.subject.trim();
+      const thinkPrefix = ':THINK:';
+      const godPrefix = ':GOD:';
+      const remainderAfterPrefix = (prefix) => rawSubject.slice(prefix.length).trimStart();
+      const replacementDelta = (fromPrefix, toPrefix) => {
+        const remainder = remainderAfterPrefix(fromPrefix);
+        const finalLength = toPrefix.length + (remainder ? 1 + remainder.length : 0);
+        return finalLength - rawSubject.length;
+      };
+
+      if (this.messageMode === 'think') {
+        if (rawSubject.startsWith(thinkPrefix)) {
+          return 200;
+        }
+        if (rawSubject.startsWith(godPrefix)) {
+          const delta = replacementDelta(godPrefix, thinkPrefix);
+          return 200 - Math.max(delta, 0);
+        }
+        return 200 - (thinkPrefix.length + 1);
+      }
+
+      if (this.messageMode === 'god') {
+        if (rawSubject.startsWith(godPrefix)) {
+          return 200;
+        }
+        if (rawSubject.startsWith(thinkPrefix)) {
+          const delta = replacementDelta(thinkPrefix, godPrefix);
+          return 200 - Math.max(delta, 0);
+        }
+        return 200 - (godPrefix.length + 1);
+      }
+
+      return 200;
+    },
+
 
     insertMarkdown(before, after, placeholder) {
       const textarea = this.$refs.bodyTextarea;


### PR DESCRIPTION
### Motivation
- Reviewers reported that the mode prefix (\":THINK:\" / \":GOD:\") could cause the final subject to exceed the server 200‑char limit and produce a 400 error.
- The helper could double‑prefix subjects and could produce inconsistent spacing when replacing prefixes.
- The subject character counter and maxlength UI were misleading because they did not reflect the final prefixed subject.

### Description
- Updated `src/mcp_agent_mail/templates/overseer_compose.html` to show the actual prefixed subject length by using `getSubjectWithMode().length` in the character counter and clarified the helper text to \"(includes mode prefix)\".
- Made `getSubjectWithMode()` idempotent and normalized spacing when replacing prefixes so inputs like `:GOD:Hello` become `:THINK: Hello` (not `:THINK:Hello`) and avoid duplicate prefixes.
- Reworked `getSubjectMaxLength()` to account for the mode prefix (including the separating space) and handle prefix→prefix replacement deltas so the input `:maxlength` correctly prevents constructing an overlong final subject.

### Testing
- Ran project pre-commit checks which executed `ruff check --fix --unsafe-fixes` and `uvx ty check`; both completed successfully.
- Pre-commit reported Bandit findings (warnings) and a dependency vulnerability check could not be completed; these are non‑blocking and were not changed by this PR.

🤖 Generated with [Claude Code](https://claude.ai/code) via MiniMax API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to subject prefixing/validation logic; main risk is off-by-one or prefix-handling edge cases that could still allow/deny sends incorrectly.
> 
> **Overview**
> Adds a **Message Mode** selector (Normal/Think/God) to the overseer composer and tracks it via new `messageMode` state.
> 
> Updates subject handling so the displayed character counter and input `maxlength` reflect the *final* mode-prefixed subject, and makes `getSubjectWithMode()` idempotent with normalized spacing and safe prefix replacement (`:THINK:`/`:GOD:`) to avoid double-prefixing and 200-char limit overruns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 345282f02aee1b385702c59d268ecf3ec57599bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Message Mode selector (Normal, Think, God) in the message composer with mode-specific visual states and helper text.
  * Subject handling now adapts to the selected mode: dynamic maximum length, real-time character count including mode prefixes, and automatic normalization to avoid duplicate prefixes when switching modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->