### PR TITLE
docs: add testing philosophy for testing_* directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ signing-*.pub
 # Local Claude settings (may contain bearer tokens; never commit)
 .claude/settings.local.json
 .claude/settings.local.json.*
+.claude/blocked_violations.log
 
 # Benchmark results - exclude transient JSON output files
 benchmarks/tmp_*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,26 @@ For development with local code changes:
 bash -lc "cd /Users/jleechan/mcp_agent_mail && ./scripts/run_server_with_token.sh >/tmp/mcp_agent_mail_server.log 2>&1 & echo \$!"
 ```
 
+## Testing Philosophy — Real Over Fake
+
+**Always prefer real end-to-end tests.** Mocks and stubs are only acceptable for isolated unit tests.
+
+For any suite or artifact under `testing_*/`:
+- No mocks
+- No monkeypatching
+- No stubbed external service behavior (Slack, GitHub, databases, etc.)
+- No direct registry/state injection
+- No modifying the system under test while claiming verification
+
+`testing_*` directories may only trigger the system from the outside and observe evidence. If a test needs simulated internals, it belongs in `src/tests/` (or equivalent unit test directory) and must not be described as end-to-end proof.
+
+When an agent tries to create a file under `testing_*/` that contains mocks or stubs, it must block itself and log the violation to `.claude/blocked_violations.log` with:
+- Timestamp
+- Full path it attempted to create
+- The specific rule violated
+
+If a real test is too slow or expensive, ask the user — do not silently downgrade to a fake.
+
 ## Running from Local Build (Testing)
 
 For testing locally built packages before publishing to PyPI:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ For development with local code changes:
 bash -lc "cd /Users/jleechan/mcp_agent_mail && ./scripts/run_server_with_token.sh >/tmp/mcp_agent_mail_server.log 2>&1 & echo \$!"
 ```
 
-## Testing Philosophy — Real Over Fake
+### Testing Philosophy — Real Over Fake
 
 **Always prefer real end-to-end tests.** Mocks and stubs are only acceptable for isolated unit tests.
 
@@ -31,16 +31,18 @@ For any suite or artifact under `testing_*/`:
 - No monkeypatching
 - No stubbed external service behavior (Slack, GitHub, databases, etc.)
 - No direct registry/state injection
-- No modifying the system under test while claiming verification
+- No modifying the system under test through internal hooks, direct state injection, or other non-public control paths while claiming verification
 
-`testing_*` directories may only trigger the system from the outside and observe evidence. If a test needs simulated internals, it belongs in `src/tests/` (or equivalent unit test directory) and must not be described as end-to-end proof.
+`testing_*/` directories may only trigger the system from the outside and observe evidence. Public/API-driven setup and teardown (e.g., using documented endpoints, test accounts, or CLI commands) is permitted. If a test needs simulated internals, it belongs in `tests/` (or equivalent unit test directory) and must not be described as end-to-end proof.
 
-When an agent tries to create a file under `testing_*/` that contains mocks or stubs, it must block itself and log the violation to `.claude/blocked_violations.log` with:
+When an agent tries to create or modify any artifact under `testing_*/` in a way that introduces any prohibited pattern above (mocks, stubs, monkeypatching, registry injection, monkey patched globals, or other banned testing-side effects), it must block itself and log the violation to `.claude/blocked_violations.log` with:
 - Timestamp
-- Full path it attempted to create
+- Full path it attempted to create or modify
 - The specific rule violated
 
 If a real test is too slow or expensive, ask the user — do not silently downgrade to a fake.
+
+See also: [Test Execution Policy](#test-execution-policy) below.
 
 ## Running from Local Build (Testing)
 


### PR DESCRIPTION
## Summary
- add testing policy to `CLAUDE.md` for `testing_*/` suites
- enforce real E2E behavior and prohibit fake internals in `testing_*/`

## Scope
- only `CLAUDE.md` changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and `.gitignore` updates only; no runtime or test behavior changes are introduced.
> 
> **Overview**
> Adds a new **“Testing Philosophy — Real Over Fake”** section to `CLAUDE.md` that explicitly bans mocks/stubs/monkeypatching and other internal state injection in any `testing_*/` artifacts, and requires agents to block and log attempted violations to `.claude/blocked_violations.log`.
> 
> Updates `.gitignore` to ignore `.claude/blocked_violations.log` so these local policy-enforcement logs aren’t committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd8b85fb3ae6913334852e62a2eb8da6c6c60c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->