### PR TITLE
fix: ensure_project and ensure_product update config instead of stale early return

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -6706,7 +6706,12 @@ def build_mcp_server() -> FastMCP:
                         prod.name = normalized_name
                         await session.commit()
                         await session.refresh(prod)
-                return {"id": prod.id, "product_uid": prod.product_uid, "name": prod.name, "created_at": _iso(prod.created_at)}
+                return {
+                    "id": prod.id,
+                    "product_uid": prod.product_uid,
+                    "name": prod.name,
+                    "created_at": _iso(prod.created_at),
+                }
             # Create with strict uid pattern; otherwise generate uid and normalize name
             import re as _re
             import uuid as _uuid

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -902,6 +902,11 @@ async def _ensure_project(human_key: str) -> Project:
         result = await session.execute(select(Project).where(Project.slug == slug))
         project = result.scalars().first()
         if project:
+            # Update human_key if it has changed (supports config updates)
+            if project.human_key != human_key:
+                project.human_key = human_key
+                await session.commit()
+                await session.refresh(project)
             # Ensure global inbox agent exists for existing project
             await _ensure_global_inbox_agent(project, session)
             return project
@@ -6684,6 +6689,8 @@ def build_mcp_server() -> FastMCP:
 
         - product_key may be a product_uid or a name
         - If both are absent, error
+
+        Idempotent: If the product exists, updates the name if provided and different.
         """
         await ensure_schema()
         key_raw = (product_key or name or "").strip()
@@ -6691,23 +6698,31 @@ def build_mcp_server() -> FastMCP:
             raise ToolExecutionError("INVALID_ARGUMENT", "Provide product_key or name.")
         async with get_session() as session:
             prod = await _get_product_by_key(session, key_raw)
-            if prod is None:
-                # Create with strict uid pattern; otherwise generate uid and normalize name
-                import re as _re
-                import uuid as _uuid
+            if prod is not None:
+                # Update name if provided and different (supports config updates)
+                if name:
+                    normalized_name = " ".join(name.strip().split())[:255]
+                    if prod.name != normalized_name:
+                        prod.name = normalized_name
+                        await session.commit()
+                        await session.refresh(prod)
+                return {"id": prod.id, "product_uid": prod.product_uid, "name": prod.name, "created_at": _iso(prod.created_at)}
+            # Create with strict uid pattern; otherwise generate uid and normalize name
+            import re as _re
+            import uuid as _uuid
 
-                uid_pattern = _re.compile(r"^[A-Fa-f0-9]{8,64}$")
-                if product_key and uid_pattern.fullmatch(product_key.strip()):
-                    uid = product_key.strip().lower()
-                else:
-                    uid = _uuid.uuid4().hex[:20]
-                display_name = (name or key_raw).strip()
-                # Collapse internal whitespace and cap length
-                display_name = " ".join(display_name.split())[:255] or uid
-                prod = Product(product_uid=uid, name=display_name)
-                session.add(prod)
-                await session.commit()
-                await session.refresh(prod)
+            uid_pattern = _re.compile(r"^[A-Fa-f0-9]{8,64}$")
+            if product_key and uid_pattern.fullmatch(product_key.strip()):
+                uid = product_key.strip().lower()
+            else:
+                uid = _uuid.uuid4().hex[:20]
+            display_name = (name or key_raw).strip()
+            # Collapse internal whitespace and cap length
+            display_name = " ".join(display_name.split())[:255] or uid
+            prod = Product(product_uid=uid, name=display_name)
+            session.add(prod)
+            await session.commit()
+            await session.refresh(prod)
         return {"id": prod.id, "product_uid": prod.product_uid, "name": prod.name, "created_at": _iso(prod.created_at)}
 
     @mcp.tool(name="products_link")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -910,7 +910,9 @@ async def test_ensure_product_updates_name(isolated_env):
         product_id1 = result1.data["id"]
 
         # Call with different name - should update
-        result2 = await client.call_tool("ensure_product", {"product_key": result1.data["product_uid"], "name": "Updated Name"})
+        result2 = await client.call_tool(
+            "ensure_product", {"product_key": result1.data["product_uid"], "name": "Updated Name"}
+        )
         assert result2.data["id"] == product_id1  # Same product
         assert result2.data["name"] == "Updated Name"  # name updated
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -833,3 +833,102 @@ async def test_project_sibling_suggestions_backend(isolated_env, monkeypatch):
     assert any(entry["peer"]["id"] == second_id for entry in updated_map[first_id]["confirmed"])
     assert not any(entry["peer"]["id"] == second_id for entry in updated_map[first_id]["suggested"])
     assert any(entry["peer"]["id"] == first_id for entry in updated_map[second_id]["confirmed"])
+
+
+@pytest.mark.asyncio
+async def test_ensure_project_idempotent(isolated_env):
+    """Test that ensure_project is idempotent - calling multiple times returns same project."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # First call creates the project
+        result1 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result1.data["slug"] == "data-projects-myproject"
+        assert result1.data["human_key"] == "/data/projects/myproject"
+        project_id1 = result1.data["id"]
+
+        # Second call should return the same project (idempotent)
+        result2 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result2.data["id"] == project_id1
+        assert result2.data["slug"] == "data-projects-myproject"
+
+        # Third call with same key should still return same project
+        result3 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result3.data["id"] == project_id1
+
+
+@pytest.mark.asyncio
+async def test_ensure_project_updates_human_key_same_slug(isolated_env):
+    """Test that ensure_project updates human_key when slug stays the same (no stale early return).
+
+    This tests the case where human_key changes but slug remains unchanged
+    (e.g., adding/removing trailing slashes, case changes).
+    """
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # Create project with initial human_key
+        result1 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result1.data["slug"] == "data-projects-myproject"
+        assert result1.data["human_key"] == "/data/projects/myproject"
+        project_id1 = result1.data["id"]
+
+        # Call with different human_key but same slug (trailing slash removed) - should update
+        result2 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject/"})
+        assert result2.data["id"] == project_id1  # Same project
+        assert result2.data["slug"] == "data-projects-myproject"  # slug unchanged
+        assert result2.data["human_key"] == "/data/projects/myproject/"  # human_key updated
+
+
+@pytest.mark.asyncio
+async def test_ensure_product_idempotent(isolated_env):
+    """Test that ensure_product is idempotent - calling multiple times returns same product."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # First call creates the product (using valid hex uid pattern - 8+ chars)
+        result1 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Test Product"})
+        assert result1.data["product_uid"] == "abc123def456"
+        assert result1.data["name"] == "Test Product"
+        product_id1 = result1.data["id"]
+
+        # Second call should return the same product (idempotent)
+        result2 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Test Product"})
+        assert result2.data["id"] == product_id1
+        assert result2.data["product_uid"] == "abc123def456"
+
+
+@pytest.mark.asyncio
+async def test_ensure_product_updates_name(isolated_env):
+    """Test that ensure_product updates name when provided and different."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # Create product with initial name
+        result1 = await client.call_tool("ensure_product", {"name": "Original Name"})
+        assert result1.data["name"] == "Original Name"
+        product_id1 = result1.data["id"]
+
+        # Call with different name - should update
+        result2 = await client.call_tool("ensure_product", {"product_key": result1.data["product_uid"], "name": "Updated Name"})
+        assert result2.data["id"] == product_id1  # Same product
+        assert result2.data["name"] == "Updated Name"  # name updated
+
+
+@pytest.mark.asyncio
+async def test_ensure_product_preserves_uid_on_name_change(isolated_env):
+    """Test that changing name via ensure_product doesn't change the product_uid."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # Create product (using valid hex uid pattern - 8+ chars, hex only a-f0-9)
+        result1 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "First Name"})
+        product_uid = result1.data["product_uid"]
+
+        # Update name only
+        result2 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Second Name"})
+
+        # UID should be preserved
+        assert result2.data["product_uid"] == product_uid
+        assert result2.data["product_uid"] == "abc123def456"
+        assert result2.data["name"] == "Second Name"


### PR DESCRIPTION
## Summary
Fixes the stale early return issue in `ensure_project` and `ensure_product` functions. Now updates config fields instead of returning stale data.

## Changes
- `_ensure_project`: Now updates `human_key` if it has changed
- `ensure_product_tool`: Now updates `name` if provided and different
- Added 5 new idempotency/update tests

## Testing
All 5 new tests pass.

Fixes jleechan-q85n

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change to idempotent create-or-get tools that now performs extra DB writes when metadata differs, covered by new async tests.
> 
> **Overview**
> Fixes stale early-return behavior in `ensure_project` and `ensure_product` so repeated calls can **update config metadata** instead of returning outdated fields.
> 
> `_ensure_project` now updates an existing project’s `human_key` when the slug matches but the provided key differs, and `ensure_product` now updates an existing product’s `name` (with normalization) when supplied and different. Adds new tests covering idempotency and the update-on-repeat-call behavior for both tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d574c7d5f0da7f1592ddb7b5766f07863e66a02e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->