### PR TITLE
fix: ensure_project and ensure_product update config instead of stale early return

### DIFF
--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -6706,7 +6706,12 @@ def build_mcp_server() -> FastMCP:
                         prod.name = normalized_name
                         await session.commit()
                         await session.refresh(prod)
-                return {"id": prod.id, "product_uid": prod.product_uid, "name": prod.name, "created_at": _iso(prod.created_at)}
+                return {
+                    "id": prod.id,
+                    "product_uid": prod.product_uid,
+                    "name": prod.name,
+                    "created_at": _iso(prod.created_at),
+                }
             # Create with strict uid pattern; otherwise generate uid and normalize name
             import re as _re
             import uuid as _uuid

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -6676,11 +6676,15 @@ def build_mcp_server() -> FastMCP:
 
     # --- Product Bus (Phase 2): ensure/link/search/resources ---------------------------------
 
-    async def _get_product_by_key(session, key: str) -> Optional[Product]:
-        # Key may match product_uid or name (case-sensitive by default)
+    async def _get_product_by_key(session, key: str) -> tuple[Optional[Product], Optional[str]]:
+        """Find product by product_uid or name. Returns (product, matched_by)."""
         stmt = select(Product).where((Product.product_uid == key) | (Product.name == key))
         res = await session.execute(stmt)
-        return res.scalars().first()
+        prod = res.scalars().first()
+        if prod is None:
+            return None, None
+        matched_by = "product_uid" if prod.product_uid == key else "name"
+        return prod, matched_by
 
     @mcp.tool(name="ensure_product")
     @_instrument_tool("ensure_product", cluster=CLUSTER_PRODUCT, capabilities={"product"})
@@ -6703,10 +6707,11 @@ def build_mcp_server() -> FastMCP:
             raise ToolExecutionError("INVALID_ARGUMENT", "Provide product_key or name.")
         async with get_session() as session:
             normalized_key = " ".join(key_raw.split())[:128] or key_raw
-            prod = await _get_product_by_key(session, normalized_key)
+            prod, matched_by = await _get_product_by_key(session, normalized_key)
             if prod is not None:
                 # Update name if provided and different (supports config updates)
-                if name is not None:
+                # Only update if found by product_uid (not by name) to preserve idempotency
+                if name is not None and matched_by == "product_uid":
                     normalized_name = " ".join(name.split())[:128]
                     if not normalized_name:
                         raise ToolExecutionError("INVALID_ARGUMENT", "Product name cannot be empty.")
@@ -6751,7 +6756,7 @@ def build_mcp_server() -> FastMCP:
         """
         await ensure_schema()
         async with get_session() as session:
-            prod = await _get_product_by_key(session, product_key.strip())
+            prod, _ = await _get_product_by_key(session, product_key.strip())
             if prod is None:
                 raise ToolExecutionError("NOT_FOUND", f"Product '{product_key}' not found.", recoverable=True)
             # Resolve project
@@ -6811,7 +6816,7 @@ def build_mcp_server() -> FastMCP:
         async def _load() -> dict[str, Any]:
             await ensure_schema()
             async with get_session() as session:
-                prod = await _get_product_by_key(session, key.strip())
+                prod, _ = await _get_product_by_key(session, key.strip())
                 if prod is None:
                     raise ToolExecutionError("NOT_FOUND", f"Product '{key}' not found.", recoverable=True)
                 proj_rows = await session.execute(
@@ -6847,7 +6852,7 @@ def build_mcp_server() -> FastMCP:
         """
         await ensure_schema()
         async with get_session() as session:
-            prod = await _get_product_by_key(session, product_key.strip())
+            prod, _ = await _get_product_by_key(session, product_key.strip())
             if prod is None:
                 raise ToolExecutionError("NOT_FOUND", f"Product '{product_key}' not found.", recoverable=True)
             proj_ids_rows = await session.execute(
@@ -6910,7 +6915,7 @@ def build_mcp_server() -> FastMCP:
         await ensure_schema()
         # Collect linked projects
         async with get_session() as session:
-            prod = await _get_product_by_key(session, product_key.strip())
+            prod, _ = await _get_product_by_key(session, product_key.strip())
             if prod is None:
                 raise ToolExecutionError("NOT_FOUND", f"Product '{product_key}' not found.", recoverable=True)
             proj_rows = await session.execute(
@@ -6964,7 +6969,7 @@ def build_mcp_server() -> FastMCP:
             criteria.append(Message.id == seed_id)
 
         async with get_session() as session:
-            prod = await _get_product_by_key(session, product_key.strip())
+            prod, _ = await _get_product_by_key(session, product_key.strip())
             if prod is None:
                 raise ToolExecutionError("NOT_FOUND", f"Product '{product_key}' not found.", recoverable=True)
             proj_ids_rows = await session.execute(

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -902,6 +902,11 @@ async def _ensure_project(human_key: str) -> Project:
         result = await session.execute(select(Project).where(Project.slug == slug))
         project = result.scalars().first()
         if project:
+            # Update human_key if it has changed (supports config updates)
+            if project.human_key != human_key:
+                project.human_key = human_key
+                await session.commit()
+                await session.refresh(project)
             # Ensure global inbox agent exists for existing project
             await _ensure_global_inbox_agent(project, session)
             return project
@@ -6684,6 +6689,8 @@ def build_mcp_server() -> FastMCP:
 
         - product_key may be a product_uid or a name
         - If both are absent, error
+
+        Idempotent: If the product exists, updates the name if provided and different.
         """
         await ensure_schema()
         key_raw = (product_key or name or "").strip()
@@ -6691,23 +6698,31 @@ def build_mcp_server() -> FastMCP:
             raise ToolExecutionError("INVALID_ARGUMENT", "Provide product_key or name.")
         async with get_session() as session:
             prod = await _get_product_by_key(session, key_raw)
-            if prod is None:
-                # Create with strict uid pattern; otherwise generate uid and normalize name
-                import re as _re
-                import uuid as _uuid
+            if prod is not None:
+                # Update name if provided and different (supports config updates)
+                if name:
+                    normalized_name = " ".join(name.strip().split())[:255]
+                    if prod.name != normalized_name:
+                        prod.name = normalized_name
+                        await session.commit()
+                        await session.refresh(prod)
+                return {"id": prod.id, "product_uid": prod.product_uid, "name": prod.name, "created_at": _iso(prod.created_at)}
+            # Create with strict uid pattern; otherwise generate uid and normalize name
+            import re as _re
+            import uuid as _uuid
 
-                uid_pattern = _re.compile(r"^[A-Fa-f0-9]{8,64}$")
-                if product_key and uid_pattern.fullmatch(product_key.strip()):
-                    uid = product_key.strip().lower()
-                else:
-                    uid = _uuid.uuid4().hex[:20]
-                display_name = (name or key_raw).strip()
-                # Collapse internal whitespace and cap length
-                display_name = " ".join(display_name.split())[:255] or uid
-                prod = Product(product_uid=uid, name=display_name)
-                session.add(prod)
-                await session.commit()
-                await session.refresh(prod)
+            uid_pattern = _re.compile(r"^[A-Fa-f0-9]{8,64}$")
+            if product_key and uid_pattern.fullmatch(product_key.strip()):
+                uid = product_key.strip().lower()
+            else:
+                uid = _uuid.uuid4().hex[:20]
+            display_name = (name or key_raw).strip()
+            # Collapse internal whitespace and cap length
+            display_name = " ".join(display_name.split())[:255] or uid
+            prod = Product(product_uid=uid, name=display_name)
+            session.add(prod)
+            await session.commit()
+            await session.refresh(prod)
         return {"id": prod.id, "product_uid": prod.product_uid, "name": prod.name, "created_at": _iso(prod.created_at)}
 
     @mcp.tool(name="products_link")

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -6700,8 +6700,10 @@ def build_mcp_server() -> FastMCP:
             prod = await _get_product_by_key(session, key_raw)
             if prod is not None:
                 # Update name if provided and different (supports config updates)
-                if name:
-                    normalized_name = " ".join(name.strip().split())[:255]
+                if name is not None:
+                    normalized_name = " ".join(name.split())[:128]
+                    if not normalized_name:
+                        raise ToolExecutionError("INVALID_ARGUMENT", "Product name cannot be empty.")
                     if prod.name != normalized_name:
                         prod.name = normalized_name
                         await session.commit()
@@ -6721,9 +6723,10 @@ def build_mcp_server() -> FastMCP:
                 uid = product_key.strip().lower()
             else:
                 uid = _uuid.uuid4().hex[:20]
-            display_name = (name or key_raw).strip()
+            raw_display_name = name if name is not None else key_raw
+            display_name = raw_display_name.strip()
             # Collapse internal whitespace and cap length
-            display_name = " ".join(display_name.split())[:255] or uid
+            display_name = " ".join(display_name.split())[:128] or uid
             prod = Product(product_uid=uid, name=display_name)
             session.add(prod)
             await session.commit()

--- a/src/mcp_agent_mail/app.py
+++ b/src/mcp_agent_mail/app.py
@@ -921,6 +921,11 @@ async def _ensure_project(human_key: str) -> Project:
             project = result.scalar_one_or_none()
             if project is None:
                 raise  # IntegrityError was from a different constraint
+            # Reconcile human_key after race-condition reload
+            if project.human_key != human_key:
+                project.human_key = human_key
+                await session.commit()
+                await session.refresh(project)
         # Create global inbox agent for new project
         await _ensure_global_inbox_agent(project, session)
         return project
@@ -6697,7 +6702,8 @@ def build_mcp_server() -> FastMCP:
         if not key_raw:
             raise ToolExecutionError("INVALID_ARGUMENT", "Provide product_key or name.")
         async with get_session() as session:
-            prod = await _get_product_by_key(session, key_raw)
+            normalized_key = " ".join(key_raw.split())[:128] or key_raw
+            prod = await _get_product_by_key(session, normalized_key)
             if prod is not None:
                 # Update name if provided and different (supports config updates)
                 if name is not None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -910,7 +910,9 @@ async def test_ensure_product_updates_name(isolated_env):
         product_id1 = result1.data["id"]
 
         # Call with different name - should update
-        result2 = await client.call_tool("ensure_product", {"product_key": result1.data["product_uid"], "name": "Updated Name"})
+        result2 = await client.call_tool(
+            "ensure_product", {"product_key": result1.data["product_uid"], "name": "Updated Name"}
+        )
         assert result2.data["id"] == product_id1  # Same product
         assert result2.data["name"] == "Updated Name"  # name updated
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 import anyio
 import pytest
@@ -886,16 +887,17 @@ async def test_ensure_product_idempotent(isolated_env):
     server = build_mcp_server()
 
     async with Client(server) as client:
+        product_key = uuid4().hex[:12]
         # First call creates the product (using valid hex uid pattern - 8+ chars)
-        result1 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Test Product"})
-        assert result1.data["product_uid"] == "abc123def456"
+        result1 = await client.call_tool("ensure_product", {"product_key": product_key, "name": "Test Product"})
+        assert result1.data["product_uid"] == product_key
         assert result1.data["name"] == "Test Product"
         product_id1 = result1.data["id"]
 
         # Second call should return the same product (idempotent)
-        result2 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Test Product"})
+        result2 = await client.call_tool("ensure_product", {"product_key": product_key, "name": "Test Product"})
         assert result2.data["id"] == product_id1
-        assert result2.data["product_uid"] == "abc123def456"
+        assert result2.data["product_uid"] == product_key
 
 
 @pytest.mark.asyncio
@@ -924,13 +926,14 @@ async def test_ensure_product_preserves_uid_on_name_change(isolated_env):
 
     async with Client(server) as client:
         # Create product (using valid hex uid pattern - 8+ chars, hex only a-f0-9)
-        result1 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "First Name"})
+        product_key = uuid4().hex[:12]
+        result1 = await client.call_tool("ensure_product", {"product_key": product_key, "name": "First Name"})
         product_uid = result1.data["product_uid"]
 
         # Update name only
-        result2 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Second Name"})
+        result2 = await client.call_tool("ensure_product", {"product_key": product_key, "name": "Second Name"})
 
         # UID should be preserved
         assert result2.data["product_uid"] == product_uid
-        assert result2.data["product_uid"] == "abc123def456"
+        assert result2.data["product_uid"] == product_key
         assert result2.data["name"] == "Second Name"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -833,3 +833,102 @@ async def test_project_sibling_suggestions_backend(isolated_env, monkeypatch):
     assert any(entry["peer"]["id"] == second_id for entry in updated_map[first_id]["confirmed"])
     assert not any(entry["peer"]["id"] == second_id for entry in updated_map[first_id]["suggested"])
     assert any(entry["peer"]["id"] == first_id for entry in updated_map[second_id]["confirmed"])
+
+
+@pytest.mark.asyncio
+async def test_ensure_project_idempotent(isolated_env):
+    """Test that ensure_project is idempotent - calling multiple times returns same project."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # First call creates the project
+        result1 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result1.data["slug"] == "data-projects-myproject"
+        assert result1.data["human_key"] == "/data/projects/myproject"
+        project_id1 = result1.data["id"]
+
+        # Second call should return the same project (idempotent)
+        result2 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result2.data["id"] == project_id1
+        assert result2.data["slug"] == "data-projects-myproject"
+
+        # Third call with same key should still return same project
+        result3 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result3.data["id"] == project_id1
+
+
+@pytest.mark.asyncio
+async def test_ensure_project_updates_human_key_same_slug(isolated_env):
+    """Test that ensure_project updates human_key when slug stays the same (no stale early return).
+
+    This tests the case where human_key changes but slug remains unchanged
+    (e.g., adding/removing trailing slashes, case changes).
+    """
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # Create project with initial human_key
+        result1 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject"})
+        assert result1.data["slug"] == "data-projects-myproject"
+        assert result1.data["human_key"] == "/data/projects/myproject"
+        project_id1 = result1.data["id"]
+
+        # Call with different human_key but same slug (trailing slash removed) - should update
+        result2 = await client.call_tool("ensure_project", {"human_key": "/data/projects/myproject/"})
+        assert result2.data["id"] == project_id1  # Same project
+        assert result2.data["slug"] == "data-projects-myproject"  # slug unchanged
+        assert result2.data["human_key"] == "/data/projects/myproject/"  # human_key updated
+
+
+@pytest.mark.asyncio
+async def test_ensure_product_idempotent(isolated_env):
+    """Test that ensure_product is idempotent - calling multiple times returns same product."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # First call creates the product (using valid hex uid pattern - 8+ chars)
+        result1 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Test Product"})
+        assert result1.data["product_uid"] == "abc123def456"
+        assert result1.data["name"] == "Test Product"
+        product_id1 = result1.data["id"]
+
+        # Second call should return the same product (idempotent)
+        result2 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Test Product"})
+        assert result2.data["id"] == product_id1
+        assert result2.data["product_uid"] == "abc123def456"
+
+
+@pytest.mark.asyncio
+async def test_ensure_product_updates_name(isolated_env):
+    """Test that ensure_product updates name when provided and different."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # Create product with initial name
+        result1 = await client.call_tool("ensure_product", {"name": "Original Name"})
+        assert result1.data["name"] == "Original Name"
+        product_id1 = result1.data["id"]
+
+        # Call with different name - should update
+        result2 = await client.call_tool("ensure_product", {"product_key": result1.data["product_uid"], "name": "Updated Name"})
+        assert result2.data["id"] == product_id1  # Same product
+        assert result2.data["name"] == "Updated Name"  # name updated
+
+
+@pytest.mark.asyncio
+async def test_ensure_product_preserves_uid_on_name_change(isolated_env):
+    """Test that changing name via ensure_product doesn't change the product_uid."""
+    server = build_mcp_server()
+
+    async with Client(server) as client:
+        # Create product (using valid hex uid pattern - 8+ chars, hex only a-f0-9)
+        result1 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "First Name"})
+        product_uid = result1.data["product_uid"]
+
+        # Update name only
+        result2 = await client.call_tool("ensure_product", {"product_key": "abc123def456", "name": "Second Name"})
+
+        # UID should be preserved
+        assert result2.data["product_uid"] == product_uid
+        assert result2.data["product_uid"] == "abc123def456"
+        assert result2.data["name"] == "Second Name"


### PR DESCRIPTION
## Summary
Fixes the stale early return issue in `ensure_project` and `ensure_product` functions. Now updates config fields instead of returning stale data.

## Changes
- `_ensure_project`: Now updates `human_key` if it has changed
- `ensure_product_tool`: Now updates `name` if provided and different  
- Constrains product name to 128 max_length (matching model definition)
- Adds empty-name guard to prevent invalid data

## Testing
All 5 new idempotency tests pass. Ruff lint passes.

Fixes jleechan-q85n

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches database-backed idempotent “ensure” flows and adds update-on-existing behavior, which could change persistence semantics for callers and needs review for unintended updates and concurrency edge cases.
> 
> **Overview**
> Fixes stale early-return behavior in `ensure_project` and `ensure_product` by reconciling mutable config fields on existing records.
> 
> `_ensure_project` now updates `Project.human_key` (including after an `IntegrityError` race reload) before returning. `ensure_product` now distinguishes whether a lookup matched by `product_uid` vs `name`, normalizes/caps names to 128 chars, rejects empty names, and updates `Product.name` when ensuring by `product_uid`.
> 
> Adds new server tests covering idempotency and update behavior for both tools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a19b54200ead0fc8a7f987441258c28033272761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->