### PR TITLE
fix: add branch hash suffix to reduce agent-name collision risk

### DIFF
--- a/scripts/auto_register_agent.sh
+++ b/scripts/auto_register_agent.sh
@@ -335,10 +335,30 @@ get_project_hash() {
   fi
 }
 
+# Generate short hash of branch name for disambiguation (6 alphanumeric chars).
+# Hashes the raw branch name (before sanitize_alphanumeric) so "feat/auth-system"
+# and "feat-auth-system" produce different suffixes despite colliding post-sanitize.
+get_branch_hash() {
+  local raw_branch="$1"
+  # xxhsum is fastest; sha256sum is most universally available
+  if command -v xxhsum >/dev/null 2>&1; then
+    echo "$raw_branch" | xxhsum -h 2>/dev/null | cut -c1-6 || \
+      echo "$raw_branch" | xxhsum | cut -c1-6
+  elif command -v sha256sum >/dev/null 2>&1; then
+    echo "$raw_branch" | sha256sum | cut -c1-6
+  elif command -v shasum >/dev/null 2>&1; then
+    echo "$raw_branch" | shasum -a 256 | cut -c1-6
+  else
+    # Final fallback: last 6 alphanumerics of the branch itself (noisy but functional)
+    echo "$raw_branch" | sanitize_alphanumeric | tail -c 6
+  fi
+}
+
 # Main logic
 BRANCH=$(get_git_branch)
 PROJECT_KEY=$(get_project_key)
 PROJECT_HASH=$(get_project_hash "$PROJECT_KEY")
+BRANCH_HASH=$(get_branch_hash "$BRANCH")
 
 # Generate memorable name from branch (2 words with hyphens)
 MEMORABLE_NAME=""
@@ -354,11 +374,17 @@ if [[ -n "$SUFFIX" ]]; then
   MEMORABLE_NAME="${MEMORABLE_NAME}-${SUFFIX}"
 fi
 
-# Add project hash for cross-repo uniqueness (e.g., "auto-register-c-3f2a1b")
+# Append branch hash for disambiguation before sanitization.
+# Example: "auto-register-c" -> "auto-register-c-a1b2c3"
+# This breaks the collision between "feat/auth-system" and "feat-auth-system"
+# (both sanitize to "featauthsystem" but differ on the hash suffix).
+MEMORABLE_NAME="${MEMORABLE_NAME}-${BRANCH_HASH}"
+
+# Add project hash for cross-repo uniqueness (e.g., "auto-register-c-a1b2c3-3f2a1b")
 MEMORABLE_NAME="${MEMORABLE_NAME}-${PROJECT_HASH}"
 
 # Agent names must be alphanumeric only - sanitize by removing hyphens
-# Example: "auto-register-c-3f2a1b" -> "autoregisterc3f2a1b"
+# Example: "auto-register-c-a1b2c3-3f2a1b" -> "autoregisterca1b2c33f2a1b"
 AGENT_NAME=$(sanitize_alphanumeric "$MEMORABLE_NAME")
 
 # Validate agent name is not empty


### PR DESCRIPTION
## Summary
- Add `get_branch_hash()` function to `auto_register_agent.sh` that computes a short (6-char alphanumeric) hash from the raw branch name before sanitization
- Append branch hash to `MEMORABLE_NAME` before the existing project hash suffix
- Example: `feat/auth-system` → `featauthsystema1b2c3`; `feat-auth-system` → `featauthsystemd4e5f6` — no collision
- `xxhsum` → `sha256sum` → `shasum` → `tail` fallback chain for portability

## Acceptance criteria (from #161)
- [x] deterministic per-branch — hash is a pure function of branch name
- [x] preserves readability — memorable name still human-readable before sanitization
- [x] avoids breaking naming rules — sanitization still strips non-alphanumerics post-hash

Refs: #161

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the derived agent name format, which may affect any workflows expecting the previous stable naming, but the logic is small and deterministic.
> 
> **Overview**
> Agent auto-registration now appends a deterministic 6-character hash derived from the *raw* git branch name before sanitization, reducing collisions where different branches collapse to the same alphanumeric string.
> 
> The script adds `get_branch_hash()` with portable hashing fallbacks and incorporates this new branch-hash suffix ahead of the existing per-repo project hash when constructing `MEMORABLE_NAME`/`AGENT_NAME`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983a37b6824f82d76680df1f2e7c0af6c97dc9f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->