### PR TITLE
fix(workflow): drop '#worldai-bugs' fallback for auto-routing

### DIFF
--- a/.github/workflows/hermes-pr-tag-listener.yml
+++ b/.github/workflows/hermes-pr-tag-listener.yml
@@ -31,7 +31,7 @@ jobs:
   notify:
     uses: jleechanorg/.github/.github/workflows/hermes-pr-tag-listener.yml@main
     with:
-      slack_channel: ${{ vars.HERMES_SLACK_CHANNEL || '#worldai-bugs' }}
+      slack_channel: ${{ vars.HERMES_SLACK_CHANNEL }}
       dispatch_ao: 'false'
     secrets:
       slack_webhook_url: ${{ secrets.HERMES_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Companion to [jleechanorg/.github PR #13](https://github.com/jleechanorg/.github/pull/13). Removes hardcoded `|| '#worldai-bugs'` fallback so the per-repo routing table (SOUL.md COMMIT `hermes-tag-webhook-per-repo-routing`) applies via auto-routing.

```diff
- slack_channel: ${{ vars.HERMES_SLACK_CHANNEL || '#worldai-bugs' }}
+ slack_channel: ${{ vars.HERMES_SLACK_CHANNEL }}
```

Refs: jleechan-7jrd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow input change with no application or security logic; misconfiguration could send notifications to the wrong channel if the variable and auto-routing are both missing.
> 
> **Overview**
> Removes the hardcoded **`#worldai-bugs`** default from the Hermes PR tag listener workflow’s `slack_channel` input.
> 
> **Before:** `slack_channel` used `vars.HERMES_SLACK_CHANNEL` with `|| '#worldai-bugs'`. **After:** it passes only `vars.HERMES_SLACK_CHANNEL`, so Slack destination is not overridden when the variable is unset and per-repo routing in the shared reusable workflow (companion change in `jleechanorg/.github`) can apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac5a771122ed6d569d5057157de155c16e7a4ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->